### PR TITLE
Don't steal pull request

### DIFF
--- a/github_app_geo_project/module/standard/changelog.py
+++ b/github_app_geo_project/module/standard/changelog.py
@@ -386,23 +386,24 @@ def generate_changelog(
         has_pr = False
         for pull_request in commit.get_pulls():
             has_pr = True
-            authors = {Author(pull_request.user.login, pull_request.user.html_url)}
-            for commit_ in pull_request.get_commits():
-                if commit_.author is not None:
-                    authors.add(Author(commit_.author.login, commit_.author.html_url))
-            pull_request.as_issue().edit(milestone=milestone)
-            changelog_items.add(
-                ChangelogItem(
-                    github=pull_request,
-                    ref=f"#{pull_request.number}",
-                    title=pull_request.title,
-                    author=Author(pull_request.user.login, pull_request.user.html_url),
-                    authors=authors,
-                    branch=pull_request.head.ref,
-                    files={github_file.filename for github_file in pull_request.get_files()},
-                    labels={label.name for label in pull_request.get_labels()},
+            if pull_request.milestone is None:
+                authors = {Author(pull_request.user.login, pull_request.user.html_url)}
+                for commit_ in pull_request.get_commits():
+                    if commit_.author is not None:
+                        authors.add(Author(commit_.author.login, commit_.author.html_url))
+                pull_request.as_issue().edit(milestone=milestone)
+                changelog_items.add(
+                    ChangelogItem(
+                        github=pull_request,
+                        ref=f"#{pull_request.number}",
+                        title=pull_request.title,
+                        author=Author(pull_request.user.login, pull_request.user.html_url),
+                        authors=authors,
+                        branch=pull_request.head.ref,
+                        files={github_file.filename for github_file in pull_request.get_files()},
+                        labels={label.name for label in pull_request.get_labels()},
+                    )
                 )
-            )
         if not has_pr:
             author = Author(commit.author.login, commit.author.html_url) if commit.author else None
             changelog_items.add(


### PR DESCRIPTION
If a pull request has already a milestone (=> considered to be in another release) don't put it in the new release.

With this, it will work better if e.g. on the master branch we do the releases `1.0.1` then `1.0.1` and `1.1.0`

With the latest version, when we do the release `1.1.0` she will steal the pull request of release `1.0.1`, it shouldn't be the sase anymore.