### PR TITLE
Separate module and GitHub event name

### DIFF
--- a/github_app_geo_project/models.py
+++ b/github_app_geo_project/models.py
@@ -36,7 +36,12 @@ class Queue(Base):
     __tablename__ = "queue"
     __table_args__ = {"schema": _SCHEMA}  # noqa: RUF012
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False, autoincrement=True)
+    id: Mapped[int] = mapped_column(
+        Integer,
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    )
     status: Mapped[str] = mapped_column(
         Unicode,
         nullable=False,
@@ -50,15 +55,19 @@ class Queue(Base):
         index=True,
     )
     started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=True)
-    finished_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
     priority: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
     application: Mapped[str] = mapped_column(Unicode, nullable=False)
     owner: Mapped[str] = mapped_column(Unicode, nullable=True)
     repository: Mapped[str] = mapped_column(Unicode, nullable=True)
-    event_name: Mapped[str] = mapped_column(Unicode, nullable=False)
-    event_data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    github_event_name: Mapped[str] = mapped_column(Unicode, nullable=False)
+    github_event_data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
     module: Mapped[str] = mapped_column(Unicode, nullable=True)
-    module_data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=True)
+    module_event_name: Mapped[str] = mapped_column(Unicode, nullable=False)
+    module_event_data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=True)
     log: Mapped[str] = mapped_column(Unicode, nullable=True)
     check_run_id: Mapped[int] = mapped_column(BigInteger, nullable=True)
 
@@ -107,7 +116,12 @@ class Output(Base):
     __tablename__ = "output"
     __table_args__ = {"schema": _SCHEMA}  # noqa: RUF012
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False, autoincrement=True)
+    id: Mapped[int] = mapped_column(
+        Integer,
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
@@ -135,6 +149,16 @@ class ModuleStatus(Base):
     __tablename__ = "module_status"
     __table_args__ = {"schema": _SCHEMA}  # noqa: RUF012
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False, autoincrement=True)
-    module: Mapped[str] = mapped_column(Unicode, nullable=False, unique=True, index=True)
+    id: Mapped[int] = mapped_column(
+        Integer,
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    )
+    module: Mapped[str] = mapped_column(
+        Unicode,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
     data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)

--- a/github_app_geo_project/module/delete_old_workflow_runs/__init__.py
+++ b/github_app_geo_project/module/delete_old_workflow_runs/__init__.py
@@ -42,7 +42,12 @@ class _ListWorkflowRunsForRepoArguments(TypedDict, total=False):
 
 
 class DeleteOldWorkflowRuns(
-    module.Module[configuration.DeleteOldWorkflowRunsConfiguration, dict[str, Any], dict[str, Any], None],
+    module.Module[
+        configuration.DeleteOldWorkflowRunsConfiguration,
+        dict[str, Any],
+        dict[str, Any],
+        None,
+    ],
 ):
     """Delete old workflow jobs."""
 
@@ -58,20 +63,28 @@ class DeleteOldWorkflowRuns(
         """Get the URL to the documentation page of the module."""
         return "https://github.com/camptocamp/github-app-geo-project/wiki/Module-%E2%80%90-Delete-Old-Workflow-Job"
 
-    def get_actions(self, context: module.GetActionContext) -> list[module.Action[dict[str, Any]]]:
+    def get_actions(
+        self,
+        context: module.GetActionContext,
+    ) -> list[module.Action[dict[str, Any]]]:
         """
         Get the action related to the module and the event.
 
         Usually the only action allowed to be done in this method is to set the pull request checks status
         Note that this function is called in the web server Pod who has low resources, and this call should be fast
         """
-        if context.event_data.get("type") == "event" and context.event_data.get("name") == "daily":
+        if (
+            context.github_event_data.get("type") == "event"
+            and context.github_event_data.get("name") == "daily"
+        ):
             return [module.Action(data={})]
         return []
 
     async def get_json_schema(self) -> dict[str, Any]:
         """Get the JSON schema for the module configuration."""
-        with (Path(__file__).parent / "schema.json").open(encoding="utf-8") as schema_file:
+        with (Path(__file__).parent / "schema.json").open(
+            encoding="utf-8",
+        ) as schema_file:
             schema = json.loads(schema_file.read())
             for key in ("$schema", "$id"):
                 if key in schema:
@@ -80,7 +93,10 @@ class DeleteOldWorkflowRuns(
 
     def get_github_application_permissions(self) -> module.GitHubApplicationPermissions:
         """Get the GitHub application permissions needed by the module."""
-        return module.GitHubApplicationPermissions(permissions={"actions": "write"}, events=set())
+        return module.GitHubApplicationPermissions(
+            permissions={"actions": "write"},
+            events=set(),
+        )
 
     async def process(
         self,
@@ -130,7 +146,9 @@ class DeleteOldWorkflowRuns(
             ).parsed_data
             for workflow_run in workflow_runs.workflow_runs:
                 if not workflow or workflow_run.name == workflow:
-                    deleted_workflows.append(f"{workflow_run.name} ({workflow_run.created_at})")
+                    deleted_workflows.append(
+                        f"{workflow_run.name} ({workflow_run.created_at})",
+                    )
                     await context.github_project.aio_github.rest.actions.async_delete_workflow_run(
                         owner=context.github_project.owner,
                         repo=context.github_project.repository,

--- a/github_app_geo_project/module/outdated_comments/__init__.py
+++ b/github_app_geo_project/module/outdated_comments/__init__.py
@@ -62,7 +62,9 @@ class OutdatedComments(module.Module[_Config, _EventData, None, None]):
 
     async def get_json_schema(self) -> dict[str, Any]:
         """Get the JSON schema for the configuration."""
-        with (Path(__file__).parent / "schema.json").open(encoding="utf-8") as schema_file:
+        with (Path(__file__).parent / "schema.json").open(
+            encoding="utf-8",
+        ) as schema_file:
             schema = json.load(schema_file)
             for key in ("$schema", "$id"):
                 if key in schema:
@@ -76,15 +78,21 @@ class OutdatedComments(module.Module[_Config, _EventData, None, None]):
             events={"pull_request_review"},
         )
 
-    def get_actions(self, context: module.GetActionContext) -> list[module.Action[_EventData]]:
+    def get_actions(
+        self,
+        context: module.GetActionContext,
+    ) -> list[module.Action[_EventData]]:
         """
         Get the action related to the module and the event.
 
         Usually the only action allowed to be done in this method is to set the pull request checks status
         Note that this function is called in the web server Pod who has low resources, and this call should be fast
         """
-        if context.event_name == "pull_request_review":
-            event_data = githubkit.webhooks.parse_obj("pull_request_review", context.event_data)
+        if context.module_event_name == "pull_request_review":
+            event_data = githubkit.webhooks.parse_obj(
+                "pull_request_review",
+                context.github_event_data,
+            )
             if event_data.action == "submitted" and isinstance(
                 event_data,
                 githubkit.versions.v2022_11_28.webhooks.pull_request_review.WebhookPullRequestReviewSubmitted,  # type: ignore[attr-defined]

--- a/github_app_geo_project/module/pull_request/checks.py
+++ b/github_app_geo_project/module/pull_request/checks.py
@@ -71,7 +71,10 @@ async def _get_code_spell_command(
     )
     if dictionaries:
         command.append("--builtin=" + ",".join(dictionaries))
-    command += code_spell_config.get("arguments", checks_configuration.CODESPELL_ARGUMENTS_DEFAULT)
+    command += code_spell_config.get(
+        "arguments",
+        checks_configuration.CODESPELL_ARGUMENTS_DEFAULT,
+    )
     return command
 
 
@@ -109,7 +112,9 @@ def _commits_messages(
             messages.append(f":x: Fixup message not allowed in commit {commit.sha}")
             success = False
         else:
-            messages.append(f":heavy_check_mark: The commit {commit.sha} is not a fixup commit")
+            messages.append(
+                f":heavy_check_mark: The commit {commit.sha} is not a fixup commit",
+            )
         if commit_message_config.get(
             "check-squash",
             checks_configuration.PULL_REQUEST_CHECKS_COMMITS_MESSAGES_SQUASH_DEFAULT,
@@ -118,7 +123,9 @@ def _commits_messages(
             messages.append(f":x: Squash message not allowed in commit {commit.sha}")
             success = False
         else:
-            messages.append(f":heavy_check_mark: The commit {commit.sha} is not a squash commit")
+            messages.append(
+                f":heavy_check_mark: The commit {commit.sha} is not a squash commit",
+            )
         if (
             commit_message_config.get(
                 "check-first-capital",
@@ -140,7 +147,10 @@ def _commits_messages(
             checks_configuration.PULL_REQUEST_CHECKS_COMMITS_MESSAGES_MIN_HEAD_LENGTH_DEFAULT,
         )
         if min_length > 0 and len(head) < min_length:
-            _LOGGER.warning("The message head should be at least %i characters long", min_length)
+            _LOGGER.warning(
+                "The message head should be at least %i characters long",
+                min_length,
+            )
             messages.append(
                 f":x: The message head should be at least {min_length} characters long in commit {commit.sha}",
             )
@@ -157,10 +167,14 @@ def _commits_messages(
             and len(commit.parents) != 1
         ):
             _LOGGER.warning("The merge commit are not allowed")
-            messages.append(f":x: The merge commit are not allowed in commit {commit.sha}")
+            messages.append(
+                f":x: The merge commit are not allowed in commit {commit.sha}",
+            )
             success = False
         else:
-            messages.append(f":heavy_check_mark: The commit {commit.sha} is not a merge commit")
+            messages.append(
+                f":heavy_check_mark: The commit {commit.sha} is not a merge commit",
+            )
         if commit_message_config.get(
             "check-no-own-revert",
             checks_configuration.PULL_REQUEST_CHECKS_COMMITS_MESSAGES_NO_OWN_REVERT_DEFAULT,
@@ -171,13 +185,18 @@ def _commits_messages(
         ):
             revert_commit_hash = message_lines[2][len("This reverts commit ") : -1]
             if revert_commit_hash in commit_hash:
-                _LOGGER.warning("Revert own commits is not allowed (%s)", revert_commit_hash)
+                _LOGGER.warning(
+                    "Revert own commits is not allowed (%s)",
+                    revert_commit_hash,
+                )
                 messages.append(
                     f":heavy_check_mark: Revert own commits is not allowed in commit {commit.sha}",
                 )
                 success = False
                 continue
-            messages.append(f":heavy_check_mark: The commit {commit.sha} is not an own revert commit")
+            messages.append(
+                f":heavy_check_mark: The commit {commit.sha} is not an own revert commit",
+            )
     return success, messages
 
 
@@ -190,7 +209,11 @@ async def _commits_spell(
     messages = []
     success = True
     for commit in commits:
-        with tempfile.NamedTemporaryFile("w+t", encoding="utf-8", suffix=".yaml") as temp_file:
+        with tempfile.NamedTemporaryFile(
+            "w+t",
+            encoding="utf-8",
+            suffix=".yaml",
+        ) as temp_file:
             if config.get(
                 "only-head",
                 checks_configuration.PULL_REQUEST_CHECKS_COMMITS_MESSAGES_ONLY_HEAD_DEFAULT,
@@ -208,14 +231,23 @@ async def _commits_spell(
             )
             async with asyncio.timeout(120):
                 stdout, stderr = await spell.communicate()
-            message = module_utils.AnsiProcessMessage.from_async_artifacts(command, spell, stdout, stderr)
+            message = module_utils.AnsiProcessMessage.from_async_artifacts(
+                command,
+                spell,
+                stdout,
+                stderr,
+            )
             if spell.returncode != 0:
                 message.title = f"Code spell error in commit {commit.sha}"
                 _LOGGER.warning(message)
                 success = False
-                messages.append(":x: " + message.title + "\n" + module_utils.html_to_markdown(message.stdout))
+                messages.append(
+                    ":x: " + message.title + "\n" + module_utils.html_to_markdown(message.stdout),
+                )
             else:
-                messages.append(f":heavy_check_mark: Code spell on commit {commit.sha} are correct")
+                messages.append(
+                    f":heavy_check_mark: Code spell on commit {commit.sha} are correct",
+                )
             message.title = f"Code spell in commit {commit.sha}"
             _LOGGER.debug(message)
     return success, messages
@@ -232,7 +264,10 @@ async def _pull_request_spell(
         temp_file.write(pull_request.title)
         temp_file.write("\n")
         if (
-            not config.get("only_head", checks_configuration.PULL_REQUEST_CHECKS_ONLY_HEAD_DEFAULT)
+            not config.get(
+                "only_head",
+                checks_configuration.PULL_REQUEST_CHECKS_ONLY_HEAD_DEFAULT,
+            )
             and pull_request.body
         ):
             temp_file.write("\n")
@@ -247,16 +282,28 @@ async def _pull_request_spell(
         )
         async with asyncio.timeout(60):
             stdout, stderr = await spell.communicate()
-        message = module_utils.AnsiProcessMessage.from_async_artifacts(command, spell, stdout, stderr)
+        message = module_utils.AnsiProcessMessage.from_async_artifacts(
+            command,
+            spell,
+            stdout,
+            stderr,
+        )
         if spell.returncode != 0:
             message.title = "Code spell error in pull request"
             _LOGGER.warning(message)
-            messages.append(":x: " + message.title + "\n" + module_utils.html_to_markdown(message.stdout))
+            messages.append(
+                ":x: " + message.title + "\n" + module_utils.html_to_markdown(message.stdout),
+            )
             return False, messages
         messages.append(
-            ":heavy_check_mark: Pull request title is correct"
-            if config.get("only_head", checks_configuration.PULL_REQUEST_CHECKS_ONLY_HEAD_DEFAULT)
-            else ":heavy_check_mark: Pull request title and body are correct",
+            (
+                ":heavy_check_mark: Pull request title is correct"
+                if config.get(
+                    "only_head",
+                    checks_configuration.PULL_REQUEST_CHECKS_ONLY_HEAD_DEFAULT,
+                )
+                else ":heavy_check_mark: Pull request title and body are correct"
+            ),
         )
 
         message.title = "Code spell in pull request"
@@ -265,7 +312,12 @@ async def _pull_request_spell(
 
 
 class Checks(
-    module.Module[checks_configuration.PullRequestChecksConfiguration, dict[str, Any], dict[str, Any], None],
+    module.Module[
+        checks_configuration.PullRequestChecksConfiguration,
+        dict[str, Any],
+        dict[str, Any],
+        None,
+    ],
 ):
     """Module to check the pull request message and commits."""
 
@@ -292,17 +344,25 @@ class Checks(
 
     async def get_json_schema(self) -> dict[str, Any]:
         """Get the JSON schema for the configuration."""
-        with (Path(__file__).parent / "checks-schema.json").open(encoding="utf-8") as schema_file:
+        with (Path(__file__).parent / "checks-schema.json").open(
+            encoding="utf-8",
+        ) as schema_file:
             schema = json.loads(schema_file.read())
             for key in ("$schema", "$id"):
                 if key in schema:
                     del schema[key]
             return schema  # type: ignore[no-any-return]
 
-    def get_actions(self, context: module.GetActionContext) -> list[module.Action[dict[str, Any]]]:
+    def get_actions(
+        self,
+        context: module.GetActionContext,
+    ) -> list[module.Action[dict[str, Any]]]:
         """Get the actions to execute."""
-        if context.event_name == "pull_request":
-            event_data = githubkit.webhooks.parse_obj("pull_request", context.event_data)
+        if context.module_event_name == "pull_request":
+            event_data = githubkit.webhooks.parse_obj(
+                "pull_request",
+                context.github_event_data,
+            )
             if event_data.action in ("opened", "reopened", "edited", "synchronize"):
                 return [
                     module.Action(
@@ -324,8 +384,11 @@ class Checks(
     ) -> module.ProcessOutput[dict[str, Any], None]:
         """Process the module."""
 
-        assert context.event_name == "pull_request"
-        event_data = githubkit.webhooks.parse_obj("pull_request", context.event_data)
+        assert context.module_event_name == "pull_request"
+        event_data = githubkit.webhooks.parse_obj(
+            "pull_request",
+            context.github_event_data,
+        )
 
         # Get the pull request and commits concurrently
         pull_request_response, commits_response = await asyncio.gather(
@@ -344,9 +407,17 @@ class Checks(
         commits = commits_response.parsed_data
 
         with tempfile.NamedTemporaryFile("w+t", encoding="utf-8") as ignore_file:
-            spellcheck_cmd = await _get_code_spell_command(context, event_data, ignore_file)
+            spellcheck_cmd = await _get_code_spell_command(
+                context,
+                event_data,
+                ignore_file,
+            )
             success_1, messages_1 = _commits_messages(context.module_config, commits)
-            success_2, messages_2 = await _commits_spell(context.module_config, commits, spellcheck_cmd)
+            success_2, messages_2 = await _commits_spell(
+                context.module_config,
+                commits,
+                spellcheck_cmd,
+            )
             success_3, messages_3 = await _pull_request_spell(
                 context.module_config,
                 pull_request,

--- a/github_app_geo_project/module/pull_request/links.py
+++ b/github_app_geo_project/module/pull_request/links.py
@@ -91,7 +91,12 @@ async def _add_issue_link(
 
 
 class Links(
-    module.Module[links_configuration.PullRequestAddLinksConfiguration, dict[str, Any], dict[str, Any], None],
+    module.Module[
+        links_configuration.PullRequestAddLinksConfiguration,
+        dict[str, Any],
+        dict[str, Any],
+        None,
+    ],
 ):
     """Module to add some links to the pull request message and commits."""
 
@@ -118,17 +123,25 @@ class Links(
 
     async def get_json_schema(self) -> dict[str, Any]:
         """Get the JSON schema for the configuration."""
-        with (Path(__file__).parent / "links-schema.json").open(encoding="utf-8") as schema_file:
+        with (Path(__file__).parent / "links-schema.json").open(
+            encoding="utf-8",
+        ) as schema_file:
             schema = json.loads(schema_file.read())
             for key in ("$schema", "$id"):
                 if key in schema:
                     del schema[key]
             return schema  # type: ignore[no-any-return]
 
-    def get_actions(self, context: module.GetActionContext) -> list[module.Action[dict[str, Any]]]:
+    def get_actions(
+        self,
+        context: module.GetActionContext,
+    ) -> list[module.Action[dict[str, Any]]]:
         """Get the actions to execute."""
-        if context.event_name == "pull_request":
-            event_data = githubkit.webhooks.parse_obj("pull_request", context.event_data)
+        if context.module_event_name == "pull_request":
+            event_data = githubkit.webhooks.parse_obj(
+                "pull_request",
+                context.github_event_data,
+            )
             if event_data.action in ("opened", "reopened", "synchronize"):
                 return [
                     module.Action(

--- a/github_app_geo_project/scripts/send_event.py
+++ b/github_app_geo_project/scripts/send_event.py
@@ -28,21 +28,28 @@ def main() -> None:
 
     c2cwsgiutils.setup_process.init(args.config_uri)
     loader = plaster.get_loader(args.config_uri)
-    engine = sqlalchemy.engine_from_config(loader.get_settings("app:app"), "sqlalchemy.")
+    engine = sqlalchemy.engine_from_config(
+        loader.get_settings("app:app"),
+        "sqlalchemy.",
+    )
     Session = sqlalchemy.orm.sessionmaker(bind=engine)  # pylint: disable=invalid-name
 
     config = loader.get_settings("app:app")
     with Session() as session:
         job = github_app_geo_project.models.Queue()
         job.application = args.application
-        job.event_name = "event"
-        job.event_data = {
+        job.github_event_name = "event"
+        job.github_event_data = {
             "type": "event",
             "name": args.event,
         }
         job.module = "dispatcher"
-        job.module_data = {
-            "modules": config.get(f"application.{args.application}.modules", "").split(),
+        job.module_event_name = "event"
+        job.module_event_data = {
+            "modules": config.get(
+                f"application.{args.application}.modules",
+                "",
+            ).split(),
         }
         job.priority = github_app_geo_project.module.PRIORITY_CRON
         session.add(job)

--- a/github_app_geo_project/templates/project.html
+++ b/github_app_geo_project/templates/project.html
@@ -147,11 +147,11 @@
             >[${job.status_enum.value}]</a
           >
           <a
-            href="${request.current_route_url(_query={**request.params, 'event_name':job.event_name})}"
+            href="${request.current_route_url(_query={**request.params, 'module_event_name':job.module_event_name})}"
             data-bs-toggle="tooltip"
             data-bs-placement="top"
             data-bs-title="Event name"
-            >${job.event_name}</a
+            >${job.module_event_name}</a
           >
           <a
             href="${request.current_route_url(_query={**request.params, 'application':job.application})}"

--- a/github_app_geo_project/views/project.py
+++ b/github_app_geo_project/views/project.py
@@ -12,7 +12,11 @@ from pyramid.view import view_config
 
 from github_app_geo_project import configuration, models, project_configuration, utils
 from github_app_geo_project.module import modules
-from github_app_geo_project.templates import pprint_duration, pprint_full_date, pprint_short_date
+from github_app_geo_project.templates import (
+    pprint_duration,
+    pprint_full_date,
+    pprint_short_date,
+)
 from github_app_geo_project.views import get_event_loop
 
 if TYPE_CHECKING:
@@ -103,7 +107,9 @@ def project(request: pyramid.request.Request) -> dict[str, Any]:
                     if "dashboard" in issue.title.lower().split() and issue.state == "open":
                         applications[app]["issue_url"] = issue.html_url
 
-            module_names.update(request.registry.settings[f"application.{app}.modules"].split())
+            module_names.update(
+                request.registry.settings[f"application.{app}.modules"].split(),
+            )
             for module_name in request.registry.settings[f"application.{app}.modules"].split():
                 module = modules.MODULES[module_name]
                 if module.required_issue_dashboard():
@@ -153,16 +159,30 @@ def project(request: pyramid.request.Request) -> dict[str, Any]:
             select_output = select_output.where(models.Output.repository == repository)
 
         if "only_error" in request.params:
-            select_output = select_output.where(models.Output.status == models.OutputStatus.ERROR)
+            select_output = select_output.where(
+                models.Output.status == models.OutputStatus.ERROR,
+            )
 
         if "status" in request.params:
-            select_job = select_job.where(models.Queue.status == request.params["status"])
-        if "event_name" in request.params:
-            select_job = select_job.where(models.Queue.event_name == request.params["event_name"])
+            select_job = select_job.where(
+                models.Queue.status == request.params["status"],
+            )
+        if "github_event_name" in request.params:
+            select_job = select_job.where(
+                models.Queue.github_event_name == request.params["github_event_name"],
+            )
+        if "module_event_name" in request.params:
+            select_job = select_job.where(
+                models.Queue.module_event_name == request.params["module_event_name"],
+            )
         if "application" in request.params:
-            select_job = select_job.where(models.Queue.application == request.params["application"])
+            select_job = select_job.where(
+                models.Queue.application == request.params["application"],
+            )
         if "module" in request.params:
-            select_job = select_job.where(models.Queue.module == request.params["module"])
+            select_job = select_job.where(
+                models.Queue.module == request.params["module"],
+            )
 
         select_output = select_output.order_by(models.Output.created_at.desc())
         select_output = select_output.limit(request.params.get("limit", 10))

--- a/tests/test_module_pull_request_links.py
+++ b/tests/test_module_pull_request_links.py
@@ -228,7 +228,8 @@ async def test_links_get_actions() -> None:
     """Test that the Links module get_actions method works correctly for pull request events."""
     # Create a mock context
     context = MagicMock()
-    context.event_name = "pull_request"
+    context.github_event_name = "pull_request"
+    context.module_event_name = "pull_request"
 
     # Create a mock pull request event
     pull_request = MagicMock()

--- a/tests/test_module_versions.py
+++ b/tests/test_module_versions.py
@@ -30,7 +30,7 @@ from github_app_geo_project.module.versions import (
 def test_get_actions() -> None:
     versions = Versions()
     context = Mock()
-    context.event_data = {"type": "event", "name": "versions-cron"}
+    context.github_event_data = {"type": "event", "name": "versions-cron"}
     actions = versions.get_actions(context)
     assert len(actions) == 1
     assert actions[0].data == _EventData(step=1)

--- a/tests/test_module_workflow.py
+++ b/tests/test_module_workflow.py
@@ -161,9 +161,10 @@ async def test_process_success() -> None:
     context = MagicMock()
     context.github_project.owner = "owner"
     context.github_project.repository = "repository"
-    context.event_name = "workflow_run"
-    context.event_data = dict(_EVENT)
-    context.event_data["workflow_run"]["conclusion"] = "success"
+    context.github_event_name = "workflow_run"
+    context.module_event_name = "workflow_run"
+    context.github_event_data = dict(_EVENT)
+    context.github_event_data["workflow_run"]["conclusion"] = "success"
 
     default_branch = AsyncMock()
     default_branch.return_value = "master"
@@ -209,9 +210,10 @@ async def test_process_failure() -> None:
     context = MagicMock()
     context.github_project.owner = "owner"
     context.github_project.repository = "repository"
-    context.event_name = "workflow_run"
-    context.event_data = dict(_EVENT)
-    context.event_data["workflow_run"]["conclusion"] = "failure"
+    context.github_event_name = "workflow_run"
+    context.module_event_name = "workflow_run"
+    context.github_event_data = dict(_EVENT)
+    context.github_event_data["workflow_run"]["conclusion"] = "failure"
 
     default_branch = AsyncMock()
     default_branch.return_value = "master"


### PR DESCRIPTION
Todo when it's merged
```bash
kubectl -n gmf-mutualize-int exec -ti deployments/ghci-app-worker -- psql 
```
```sql
ALTER TABLE ghci.queue RENAME COLUMN event_name TO github_event_name;
ALTER TABLE ghci.queue RENAME COLUMN event_data TO github_event_data;
ALTER TABLE ghci.queue RENAME COLUMN module_data TO module_event_data;
ALTER TABLE ghci.queue ADD COLUMN module_event_name VARCHAR;
UPDATE ghci.queue SET module_event_name = github_event_name;
ALTER TABLE ghci.queue ALTER COLUMN module_event_name SET NOT NULL;

UPDATE ghci.queue SET status = 'NEW', check_run_id = '' WHERE id = 681289
```
