### PR TITLE
Versions: Format endoflife.date dates as jj/mm/aaaa

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ The modules should be reasonably tested in `tests/test_module_<name>.py`.
 
 The module types (`configuration`, `event data`, `transversal status`, `intermediate status`) should be strongly-typed, the configuration must comes from the generated `configuration.py`. the others must be Pydantic models or `None`, and should not use untyped `dict`.
 
+Avoid `model_serializer` whenever possible.
+
 ## Important classes
 
 ### ProcessContext
@@ -61,6 +63,8 @@ Run tests: `poetry run pytest -vv tests`.
 Do not use the conventional commit conventions.
 The commit messages should start with a capital.
 If necessary, for example for a commit that concerns only one module, use the format: 'Context: Message' (with a message that starts with an uppercase).
+
+Before each commit ensure that `poetry run prospector --output-format=pylint --ignore-paths=scripts` and `poetry run pytest -vv tests` do not return errors.
 
 ## Future
 

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -1525,10 +1525,7 @@ def _support_cmp(a: str | _SupportType | _Support, b: str | _SupportType | _Supp
     return 0
 
 
-def _is_supported(
-    base: str | _SupportType | _Support,
-    other: str | _SupportType | _Support,
-) -> bool:
+def _is_supported(base: _Support, other: _Support) -> bool:
     """
     Determine if a version is supported based on two support status strings.
 

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -1337,12 +1337,12 @@ async def _update_upstream_versions(
             else:
                 if not isinstance(eol, str):
                     continue
-                if utils.datetime_with_timezone(
+                parsed_eol = utils.datetime_with_timezone(
                     datetime.datetime.fromisoformat(eol),
-                ) < datetime.datetime.now(
-                    datetime.UTC,
-                ):
+                )
+                if parsed_eol < datetime.datetime.now(datetime.UTC):
                     continue
+                eol = parsed_eol.astimezone(datetime.UTC).strftime("%d/%m/%Y")
             package_status.versions[cycle["cycle"]] = _TransversalStatusVersion(
                 support=eol,
                 names_by_datasource={

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -136,6 +136,12 @@ class _Support(BaseModel):
     type: _SupportType = _SupportType.NO_SUPPORT_DEFINED
     until: datetime.date | None = None
 
+    @property
+    def display(self) -> str:
+        if self.type == _SupportType.DATE and self.until is not None:
+            return self.until.strftime("%d/%m/%Y")
+        return self.type.value
+
     @model_validator(mode="before")
     @classmethod
     def _from_str(cls, data: Any) -> Any:
@@ -244,12 +250,6 @@ class _DependencyBase(BaseModel):
     support: _Support
     color: str
     repo: str
-
-    @property
-    def support_display(self) -> str:
-        if self.support.type == _SupportType.DATE and self.support.until is not None:
-            return self.support.until.strftime("%d/%m/%Y")
-        return self.support.type.value
 
 
 class _Dependency(_DependencyBase):

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -31,10 +31,6 @@ from github_app_geo_project.module.versions import configuration
 
 _LOGGER = logging.getLogger(__name__)
 
-_NO_SUPPORT_DEFINED = "No support defined"
-_UNSUPPORTED = "Unsupported"
-_BEST_EFFORT = "Best effort"
-_TO_BE_DEFINED = "To be defined"
 _UNSUPPORTED_COLOR = "--bs-danger"
 _SUPPORTED_COLOR = "--bs-body-bg"
 
@@ -49,12 +45,18 @@ class _SupportCategory(IntEnum):
 
 
 class _SupportType(Enum):
-    NO_SUPPORT_DEFINED = _NO_SUPPORT_DEFINED
-    UNSUPPORTED = _UNSUPPORTED
-    BEST_EFFORT = _BEST_EFFORT
-    TO_BE_DEFINED = _TO_BE_DEFINED
+    NO_SUPPORT_DEFINED = "No support defined"
+    UNSUPPORTED = "Unsupported"
+    BEST_EFFORT = "Best effort"
+    TO_BE_DEFINED = "To be defined"
     DATE = "Date"
     UNKNOWN = "Unknown"
+
+
+def _support_display(support: "_Support") -> str:
+    if support.type == _SupportType.DATE and support.until is not None:
+        return support.until.strftime("%d/%m/%Y")
+    return support.type.value
 
 
 class _TransversalStatusNameByDatasource(BaseModel):
@@ -177,7 +179,7 @@ class _Support(BaseModel):
 
     @model_validator(mode="after")
     def _set_until_from_type(self) -> "_Support":
-        if self.until is None and self.type not in (_SupportType.DATE, _SupportType.UNKNOWN):
+        if self.until is None and self.type != _SupportType.UNKNOWN:
             self.until = _parse_support_date_value(str(self.type.value))
         return self
 
@@ -249,6 +251,17 @@ class _DependencyBase(BaseModel):
     color: str
     repo: str
 
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_support(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "support" in data:
+            value = data.get("support")
+            if isinstance(value, _Support):
+                data = {**data, "support": _support_display(value)}
+            elif isinstance(value, dict):
+                data = {**data, "support": _support_display(_Support(**value))}
+        return data
+
 
 class _Dependency(_DependencyBase):
     datasource: str
@@ -259,7 +272,7 @@ class _DependencyReverse(_DependencyBase):
 
 
 class _Dependencies(BaseModel):
-    support: _Support = Field(default_factory=lambda: _Support(type=_UNSUPPORTED))
+    support: _Support = Field(default_factory=lambda: _Support(type=_SupportType.UNSUPPORTED))
     color: str = _UNSUPPORTED_COLOR
     forward: list[_Dependency] = []
     reverse: list[_DependencyReverse] = []
@@ -408,7 +421,7 @@ class Versions(
             stabilization_versions.append(default_branch)
             _LOGGER.debug("Versions: %s", ", ".join(stabilization_versions))
             for version in stabilization_versions:
-                intermediate_status.version_support[version] = _BEST_EFFORT
+                intermediate_status.version_support[version] = _SupportType.BEST_EFFORT.value
 
             if security is not None:
                 version_index = security.version_index
@@ -616,7 +629,11 @@ class Versions(
                 intermediate_version_name,
                 _TransversalStatusVersion(
                     support=_Support(
-                        type=(_BEST_EFFORT if repo.has_security_policy else _NO_SUPPORT_DEFINED),
+                        type=(
+                            _SupportType.BEST_EFFORT
+                            if repo.has_security_policy
+                            else _SupportType.NO_SUPPORT_DEFINED
+                        ),
                     ),
                 ),
             )
@@ -898,7 +915,9 @@ def _rebuild_repo_names(repo_data: "_TransversalStatusRepo") -> None:
                 ).by_package.setdefault(
                     name,
                     _TransversalStatusNamesByVersion(),
-                ).by_version[_canonical_minor_version(datasource, branch)] = branch_data.support.type
+                ).by_version[_canonical_minor_version(datasource, branch)] = _support_display(
+                    branch_data.support,
+                )
     repo_data.names_index = names_index
 
 
@@ -1391,7 +1410,7 @@ async def _update_upstream_versions(
             eol = cycle.get("eol")
             support_until = None
             if eol is False:
-                eol = _BEST_EFFORT
+                eol = _SupportType.BEST_EFFORT.value
             else:
                 if not isinstance(eol, str):
                     continue
@@ -1438,13 +1457,13 @@ def _parse_support_date_value(text: str) -> datetime.date | None:
 
 def _support_category(s: str, support_until: datetime.date | None = None) -> _SupportCategory:
     s = (s or "").strip().lower()
-    if s == _NO_SUPPORT_DEFINED.lower():
+    if s == _SupportType.NO_SUPPORT_DEFINED.value.lower():
         return _SupportCategory.NO_SUPPORT_DEFINED
-    if s == _UNSUPPORTED.lower():
+    if s == _SupportType.UNSUPPORTED.value.lower():
         return _SupportCategory.UNSUPPORTED
-    if s == _BEST_EFFORT.lower():
+    if s == _SupportType.BEST_EFFORT.value.lower():
         return _SupportCategory.BEST_EFFORT
-    if s == _TO_BE_DEFINED.lower():
+    if s == _SupportType.TO_BE_DEFINED.value.lower():
         return _SupportCategory.TO_BE_DEFINED
     if support_until is not None or _parse_support_date(s) is not None:
         return _SupportCategory.DATE
@@ -1584,9 +1603,11 @@ def _build_internal_dependencies(
                 if datasource_name == "docker":
                     status_values = set(dependency_package_data.status_by_version.values())
                     if not status_values:
-                        support = _NO_SUPPORT_DEFINED
+                        support = _SupportType.NO_SUPPORT_DEFINED.value
                     else:
-                        real_statuses = {s for s in status_values if s != _NO_SUPPORT_DEFINED}
+                        real_statuses = {
+                            s for s in status_values if s != _SupportType.NO_SUPPORT_DEFINED.value
+                        }
                         candidates = list(real_statuses or status_values)
                         support = candidates[0]
                         for other_support in candidates[1:]:
@@ -1595,12 +1616,12 @@ def _build_internal_dependencies(
                 elif not dependency_package_data.has_security_policy:
                     support = dependency_package_data.status_by_version.get(
                         dependency_minor,
-                        _NO_SUPPORT_DEFINED,
+                        _SupportType.NO_SUPPORT_DEFINED.value,
                     )
                 else:
                     support = dependency_package_data.status_by_version.get(
                         dependency_minor,
-                        _UNSUPPORTED,
+                        _SupportType.UNSUPPORTED.value,
                     )
                 clean_dependency_version = _clean_version(dependency_version)
                 dependencies_branch.forward.append(
@@ -1690,7 +1711,7 @@ def _build_reverse_dependency(
                                 _DependencyReverse(
                                     name=other_repo,
                                     version=_clean_version(other_version),
-                                    support=other_version_data.support.type.value,
+                                    support=_support_display(other_version_data.support),
                                     color=(
                                         _SUPPORTED_COLOR
                                         if _is_supported(
@@ -1710,9 +1731,9 @@ def _build_reverse_dependency(
                                 _Dependencies(
                                     support=_Support(
                                         type=(
-                                            _UNSUPPORTED
+                                            _SupportType.UNSUPPORTED
                                             if repo_data.has_security_policy
-                                            else _NO_SUPPORT_DEFINED
+                                            else _SupportType.NO_SUPPORT_DEFINED
                                         ),
                                     ),
                                     color=(
@@ -1725,7 +1746,7 @@ def _build_reverse_dependency(
                                 _DependencyReverse(
                                     name=other_repo,
                                     version=_clean_version(other_version),
-                                    support=other_version_data.support.type.value,
+                                    support=_support_display(other_version_data.support),
                                     color=(
                                         _SUPPORTED_COLOR
                                         if not repo_data.has_security_policy
@@ -1767,7 +1788,7 @@ def _apply_additional_packages(
                 for name in other_name.names:
                     support_index.setdefault(
                         (other_datasource_name, name, normalized_other_version), []
-                    ).append(other_version_data.support.type.value)
+                    ).append(_support_display(other_version_data.support))
 
     for repo, data in context.module_config.get("additional-packages", {}).items():
         module_utils.manage_updated_separated(
@@ -1785,7 +1806,7 @@ def _apply_additional_packages(
                     continue
                 deps_by_datasource = version_data.get("dependencies_by_datasource")
                 if not isinstance(deps_by_datasource, dict):
-                    version_data["support"] = _NO_SUPPORT_DEFINED
+                    version_data["support"] = _SupportType.NO_SUPPORT_DEFINED.value
                     continue
                 # Gather all dependency supports using the pre-built index
                 supports = []
@@ -1822,14 +1843,14 @@ def _apply_additional_packages(
                             min_support = s
                     version_data["support"] = min_support
                 else:
-                    version_data["support"] = _UNSUPPORTED
+                    version_data["support"] = _SupportType.UNSUPPORTED.value
 
         if isinstance(data, dict):
             versions = data.get("versions")
             if isinstance(versions, dict):
                 for version_data in versions.values():
                     if isinstance(version_data, dict) and "support" not in version_data:
-                        version_data["support"] = _NO_SUPPORT_DEFINED
+                        version_data["support"] = _SupportType.NO_SUPPORT_DEFINED.value
 
         pydentic_data = _TransversalStatusRepo(**data)
         _rebuild_repo_names(pydentic_data)

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -127,8 +127,33 @@ class _TransversalStatusNamesIndex(BaseModel):
         return self.by_datasource
 
 
+class _Support(BaseModel):
+    type: str = _NO_SUPPORT_DEFINED
+    until: datetime.date | None = None
+
+    @model_serializer(mode="plain")
+    def _to_plain(self) -> dict[str, Any]:
+        data: dict[str, Any] = {"type": self.type}
+        if self.until is not None:
+            data["until"] = self.until
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def _from_str(cls, data: Any) -> Any:
+        if isinstance(data, str):
+            return {"type": data}
+        return data
+
+    @model_validator(mode="after")
+    def _set_until_from_type(self) -> "_Support":
+        if self.until is None:
+            self.until = _parse_support_date_value(self.type)
+        return self
+
+
 class _TransversalStatusVersion(BaseModel):
-    support: str = _NO_SUPPORT_DEFINED
+    support: _Support = Field(default_factory=_Support)
     names_by_datasource: dict[str, _TransversalStatusNameByDatasource] = {}
     dependencies_by_datasource: dict[str, _TransversalStatusNameInDatasource] = {}
 
@@ -204,7 +229,7 @@ class _DependencyReverse(_DependencyBase):
 
 
 class _Dependencies(BaseModel):
-    support: str = _UNSUPPORTED
+    support: _Support = Field(default_factory=lambda: _Support(type=_UNSUPPORTED))
     color: str = _UNSUPPORTED_COLOR
     forward: list[_Dependency] = []
     reverse: list[_DependencyReverse] = []
@@ -533,9 +558,9 @@ class Versions(
             for version_name, support in intermediate_status.version_support.items():
                 version = repo.versions.setdefault(
                     version_name,
-                    _TransversalStatusVersion(support=support),
+                    _TransversalStatusVersion(support=_Support(type=support)),
                 )
-                version.support = support
+                version.support = _Support(type=support)
 
             if intermediate_status.stabilization_versions:
                 for version_name in list(versions.keys()):
@@ -560,7 +585,9 @@ class Versions(
             version = versions.setdefault(
                 intermediate_version_name,
                 _TransversalStatusVersion(
-                    support=(_BEST_EFFORT if repo.has_security_policy else _NO_SUPPORT_DEFINED),
+                    support=_Support(
+                        type=(_BEST_EFFORT if repo.has_security_policy else _NO_SUPPORT_DEFINED),
+                    ),
                 ),
             )
             if intermediate_status.version_names_by_datasource:
@@ -841,7 +868,7 @@ def _rebuild_repo_names(repo_data: "_TransversalStatusRepo") -> None:
                 ).by_package.setdefault(
                     name,
                     _TransversalStatusNamesByVersion(),
-                ).by_version[_canonical_minor_version(datasource, branch)] = branch_data.support
+                ).by_version[_canonical_minor_version(datasource, branch)] = branch_data.support.type
     repo_data.names_index = names_index
 
 
@@ -1332,6 +1359,7 @@ async def _update_upstream_versions(
         _LOGGER.debug(message)
         for cycle in cycles:
             eol = cycle.get("eol")
+            support_until = None
             if eol is False:
                 eol = _BEST_EFFORT
             else:
@@ -1342,9 +1370,10 @@ async def _update_upstream_versions(
                 )
                 if parsed_eol < datetime.datetime.now(datetime.UTC):
                     continue
+                support_until = parsed_eol.astimezone(datetime.UTC).date()
                 eol = parsed_eol.astimezone(datetime.UTC).strftime("%d/%m/%Y")
             package_status.versions[cycle["cycle"]] = _TransversalStatusVersion(
-                support=eol,
+                support=_Support(type=eol, until=support_until),
                 names_by_datasource={
                     datasource: _TransversalStatusNameByDatasource(
                         names=[package],
@@ -1370,7 +1399,14 @@ def _parse_support_date(text: str) -> datetime.datetime | None:
     return None
 
 
-def _support_category(s: str) -> _SupportCategory:
+def _parse_support_date_value(text: str) -> datetime.date | None:
+    parsed = _parse_support_date(text)
+    if parsed is None:
+        return None
+    return parsed.astimezone(datetime.UTC).date()
+
+
+def _support_category(s: str, support_until: datetime.date | None = None) -> _SupportCategory:
     s = (s or "").strip().lower()
     if s == _NO_SUPPORT_DEFINED.lower():
         return _SupportCategory.NO_SUPPORT_DEFINED
@@ -1380,12 +1416,17 @@ def _support_category(s: str) -> _SupportCategory:
         return _SupportCategory.BEST_EFFORT
     if s == _TO_BE_DEFINED.lower():
         return _SupportCategory.TO_BE_DEFINED
-    if _parse_support_date(s) is not None:
+    if support_until is not None or _parse_support_date(s) is not None:
         return _SupportCategory.DATE
     return _SupportCategory.UNKNOWN  # Any other string
 
 
-def _support_cmp(a: str, b: str) -> int:
+def _support_cmp(
+    a: str,
+    b: str,
+    a_support_until: datetime.date | None = None,
+    b_support_until: datetime.date | None = None,
+) -> int:
     """
     Compare two support status strings.
 
@@ -1404,8 +1445,8 @@ def _support_cmp(a: str, b: str) -> int:
     a_norm = (a or "").strip()
     b_norm = (b or "").strip()
 
-    cat_a = _support_category(a_norm)
-    cat_b = _support_category(b_norm)
+    cat_a = _support_category(a_norm, a_support_until)
+    cat_b = _support_category(b_norm, b_support_until)
     if _SupportCategory.NO_SUPPORT_DEFINED in (cat_a, cat_b):
         # No support defined is considered equal to everything to never be in red
         return 0
@@ -1414,8 +1455,8 @@ def _support_cmp(a: str, b: str) -> int:
     if cat_a == _SupportCategory.DATE and cat_b == _SupportCategory.DATE:
         # Both are dates, compare as dates (oldest = less support)
         try:
-            da = _parse_support_date(a_norm)
-            db = _parse_support_date(b_norm)
+            da = a_support_until or _parse_support_date_value(a_norm)
+            db = b_support_until or _parse_support_date_value(b_norm)
             if da is None or db is None:
                 message = f"Failed to parse support dates for comparison: {a!r}, {b!r}"
                 raise ValueError(message)  # noqa: TRY301
@@ -1430,7 +1471,12 @@ def _support_cmp(a: str, b: str) -> int:
     return 0
 
 
-def _is_supported(base: str, other: str) -> bool:
+def _is_supported(
+    base: str,
+    other: str,
+    base_support_until: datetime.date | None = None,
+    other_support_until: datetime.date | None = None,
+) -> bool:
     """
     Determine if a version is supported based on two support status strings.
 
@@ -1447,7 +1493,15 @@ def _is_supported(base: str, other: str) -> bool:
         True if the other status is supported relative to the base, False otherwise
     """
     # Use the comparison: other is supported if it is at least as good as base
-    return _support_cmp(base, other) <= 0
+    return (
+        _support_cmp(
+            base,
+            other,
+            a_support_until=base_support_until,
+            b_support_until=other_support_until,
+        )
+        <= 0
+    )
 
 
 def _build_internal_dependencies(
@@ -1532,7 +1586,11 @@ def _build_internal_dependencies(
                         color=(
                             _SUPPORTED_COLOR
                             if dependency_package_data.has_security_policy is False
-                            or _is_supported(version_data.support, support)
+                            or _is_supported(
+                                version_data.support.type,
+                                support,
+                                base_support_until=version_data.support.until,
+                            )
                             else _UNSUPPORTED_COLOR
                         ),
                         repo=dependency_package_data.repo or "-",
@@ -1602,12 +1660,14 @@ def _build_reverse_dependency(
                                 _DependencyReverse(
                                     name=other_repo,
                                     version=_clean_version(other_version),
-                                    support=other_version_data.support,
+                                    support=other_version_data.support.type,
                                     color=(
                                         _SUPPORTED_COLOR
                                         if _is_supported(
-                                            other_version_data.support,
-                                            version_data.support,
+                                            other_version_data.support.type,
+                                            version_data.support.type,
+                                            base_support_until=other_version_data.support.until,
+                                            other_support_until=version_data.support.until,
                                         )
                                         else _UNSUPPORTED_COLOR
                                     ),
@@ -1618,8 +1678,12 @@ def _build_reverse_dependency(
                             dependencies_branches.by_branch.setdefault(
                                 target_version,
                                 _Dependencies(
-                                    support=(
-                                        _UNSUPPORTED if repo_data.has_security_policy else _NO_SUPPORT_DEFINED
+                                    support=_Support(
+                                        type=(
+                                            _UNSUPPORTED
+                                            if repo_data.has_security_policy
+                                            else _NO_SUPPORT_DEFINED
+                                        ),
                                     ),
                                     color=(
                                         _UNSUPPORTED_COLOR
@@ -1631,7 +1695,7 @@ def _build_reverse_dependency(
                                 _DependencyReverse(
                                     name=other_repo,
                                     version=_clean_version(other_version),
-                                    support=other_version_data.support,
+                                    support=other_version_data.support.type,
                                     color=(
                                         _SUPPORTED_COLOR
                                         if not repo_data.has_security_policy
@@ -1673,7 +1737,7 @@ def _apply_additional_packages(
                 for name in other_name.names:
                     support_index.setdefault(
                         (other_datasource_name, name, normalized_other_version), []
-                    ).append(other_version_data.support)
+                    ).append(other_version_data.support.type)
 
     for repo, data in context.module_config.get("additional-packages", {}).items():
         module_utils.manage_updated_separated(

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -1470,18 +1470,15 @@ def _support_category(s: str, support_until: datetime.date | None = None) -> _Su
     return _SupportCategory.UNKNOWN  # Any other string
 
 
-def _support_value(value: str | _SupportType) -> str:
+def _support_value(value: str | _SupportType | _Support) -> str:
+    if isinstance(value, _Support):
+        return value.type.value
     if isinstance(value, _SupportType):
         return value.value
     return value
 
 
-def _support_cmp(
-    a: str | _SupportType,
-    b: str | _SupportType,
-    a_support_until: datetime.date | None = None,
-    b_support_until: datetime.date | None = None,
-) -> int:
+def _support_cmp(a: str | _SupportType | _Support, b: str | _SupportType | _Support) -> int:
     """
     Compare two support status strings.
 
@@ -1499,9 +1496,11 @@ def _support_cmp(
     # Normalize once and use consistently for category and date parsing
     a_norm = (_support_value(a) or "").strip()
     b_norm = (_support_value(b) or "").strip()
+    a_until = a.until if isinstance(a, _Support) else None
+    b_until = b.until if isinstance(b, _Support) else None
 
-    cat_a = _support_category(a_norm, a_support_until)
-    cat_b = _support_category(b_norm, b_support_until)
+    cat_a = _support_category(a_norm, a_until)
+    cat_b = _support_category(b_norm, b_until)
     if _SupportCategory.NO_SUPPORT_DEFINED in (cat_a, cat_b):
         # No support defined is considered equal to everything to never be in red
         return 0
@@ -1510,8 +1509,8 @@ def _support_cmp(
     if cat_a == _SupportCategory.DATE and cat_b == _SupportCategory.DATE:
         # Both are dates, compare as dates (oldest = less support)
         try:
-            da = a_support_until or _parse_support_date_value(a_norm)
-            db = b_support_until or _parse_support_date_value(b_norm)
+            da = a_until or _parse_support_date_value(a_norm)
+            db = b_until or _parse_support_date_value(b_norm)
             if da is None or db is None:
                 message = f"Failed to parse support dates for comparison: {a!r}, {b!r}"
                 raise ValueError(message)  # noqa: TRY301
@@ -1527,10 +1526,8 @@ def _support_cmp(
 
 
 def _is_supported(
-    base: str | _SupportType,
-    other: str | _SupportType,
-    base_support_until: datetime.date | None = None,
-    other_support_until: datetime.date | None = None,
+    base: str | _SupportType | _Support,
+    other: str | _SupportType | _Support,
 ) -> bool:
     """
     Determine if a version is supported based on two support status strings.
@@ -1548,15 +1545,7 @@ def _is_supported(
         True if the other status is supported relative to the base, False otherwise
     """
     # Use the comparison: other is supported if it is at least as good as base
-    return (
-        _support_cmp(
-            base,
-            other,
-            a_support_until=base_support_until,
-            b_support_until=other_support_until,
-        )
-        <= 0
-    )
+    return _support_cmp(base, other) <= 0
 
 
 def _build_internal_dependencies(
@@ -1644,9 +1633,8 @@ def _build_internal_dependencies(
                             _SUPPORTED_COLOR
                             if dependency_package_data.has_security_policy is False
                             or _is_supported(
-                                version_data.support.type.value,
+                                version_data.support,
                                 support,
-                                base_support_until=version_data.support.until,
                             )
                             else _UNSUPPORTED_COLOR
                         ),
@@ -1721,10 +1709,8 @@ def _build_reverse_dependency(
                                     color=(
                                         _SUPPORTED_COLOR
                                         if _is_supported(
-                                            other_version_data.support.type.value,
-                                            version_data.support.type.value,
-                                            base_support_until=other_version_data.support.until,
-                                            other_support_until=version_data.support.until,
+                                            other_version_data.support,
+                                            version_data.support,
                                         )
                                         else _UNSUPPORTED_COLOR
                                     ),

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -100,7 +100,7 @@ class _TransversalStatusNamesByVersion(BaseModel):
     @model_validator(mode="after")
     def _normalize_supports(self) -> _TransversalStatusNamesByVersion:
         self.by_version = {
-            key: value if isinstance(value, _Support) else _Support(type=_SupportType(value))
+            key: value if isinstance(value, _Support) else _Support.model_validate(value)
             for key, value in self.by_version.items()
         }
         return self
@@ -160,6 +160,8 @@ class _Support(BaseModel):
             }
         if isinstance(data, dict) and "type" in data:
             raw_type = data.get("type")
+            if isinstance(raw_type, _SupportType):
+                return {**data, "type": raw_type}
             if raw_type is None:
                 return {**data, "type": _SupportType.UNKNOWN}
             if isinstance(raw_type, str):
@@ -1413,7 +1415,7 @@ async def _update_upstream_versions(
                 support_until = parsed_eol.astimezone(datetime.UTC).date()
                 eol = parsed_eol.astimezone(datetime.UTC).strftime("%d/%m/%Y")
             package_status.versions[cycle["cycle"]] = _TransversalStatusVersion(
-                support=_Support(type=_SupportType(eol), until=support_until),
+                support=_Support(type=_SupportType.DATE, until=support_until),
                 names_by_datasource={
                     datasource: _TransversalStatusNameByDatasource(
                         names=[package],

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -23,7 +23,7 @@ import githubkit.exception
 import githubkit.versions.latest.models
 import security_md
 import yaml
-from pydantic import BaseModel, Field, model_serializer, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from github_app_geo_project import module, utils
 from github_app_geo_project.module import ProcessOutput
@@ -111,10 +111,6 @@ class _TransversalStatusNamesByVersion(BaseModel):
         }
         return self
 
-    @model_serializer(mode="plain")
-    def _to_flat(self) -> dict[str, Any]:
-        return {key: _support_display(value) for key, value in self.by_version.items()}
-
 
 class _TransversalStatusNamesByPackage(BaseModel):
     """Map package name -> versions map for one datasource."""
@@ -127,10 +123,6 @@ class _TransversalStatusNamesByPackage(BaseModel):
         if isinstance(data, dict) and "by_package" not in data:
             return {"by_package": data}
         return data
-
-    @model_serializer(mode="plain")
-    def _to_flat(self) -> dict[str, _TransversalStatusNamesByVersion]:
-        return self.by_package
 
 
 class _TransversalStatusNamesIndex(BaseModel):
@@ -145,21 +137,10 @@ class _TransversalStatusNamesIndex(BaseModel):
             return {"by_datasource": data}
         return data
 
-    @model_serializer(mode="plain")
-    def _to_flat(self) -> dict[str, _TransversalStatusNamesByPackage]:
-        return self.by_datasource
-
 
 class _Support(BaseModel):
     type: _SupportType = _SupportType.NO_SUPPORT_DEFINED
     until: datetime.date | None = None
-
-    @model_serializer(mode="plain")
-    def _to_plain(self) -> dict[str, Any]:
-        data: dict[str, Any] = {"type": self.type.value}
-        if self.until is not None:
-            data["until"] = self.until
-        return data
 
     @model_validator(mode="before")
     @classmethod

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -1,5 +1,7 @@
 """Utility functions for the auto* modules."""
 
+from __future__ import annotations
+
 import asyncio
 import base64
 import datetime
@@ -10,10 +12,9 @@ import os
 import re
 import tempfile
 import tomllib
-from collections.abc import Iterable
 from enum import Enum, IntEnum
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 import anyio
@@ -28,6 +29,9 @@ from github_app_geo_project import module, utils
 from github_app_geo_project.module import ProcessOutput
 from github_app_geo_project.module import utils as module_utils
 from github_app_geo_project.module.versions import configuration
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,10 +57,26 @@ class _SupportType(Enum):
     UNKNOWN = "Unknown"
 
 
-def _support_display(support: "_Support") -> str:
+def _support_display(support: _Support) -> str:
     if support.type == _SupportType.DATE and support.until is not None:
         return support.until.strftime("%d/%m/%Y")
     return support.type.value
+
+
+def _support_from_value(value: str | _SupportType | _Support) -> _Support:
+    if isinstance(value, _Support):
+        return value
+    if isinstance(value, _SupportType):
+        return _Support(type=value)
+    normalized = value.strip()
+    parsed_date = _parse_support_date_value(normalized)
+    if parsed_date is not None:
+        return _Support(type=_SupportType.DATE, until=parsed_date)
+    lowered = normalized.lower()
+    for support_type in _SupportType:
+        if support_type.value.lower() == lowered:
+            return _Support(type=support_type)
+    return _Support(type=_SupportType.UNKNOWN)
 
 
 class _TransversalStatusNameByDatasource(BaseModel):
@@ -178,7 +198,7 @@ class _Support(BaseModel):
         return data
 
     @model_validator(mode="after")
-    def _set_until_from_type(self) -> "_Support":
+    def _set_until_from_type(self) -> _Support:
         if self.until is None and self.type != _SupportType.UNKNOWN:
             self.until = _parse_support_date_value(str(self.type.value))
         return self
@@ -768,7 +788,7 @@ class _Version:
         """
         self.version = version
 
-    def __cmp__(self, other: "_Version") -> int:
+    def __cmp__(self, other: _Version) -> int:
         r"""
         Compare this version with another.
 
@@ -812,7 +832,7 @@ class _Version:
             return 0
         return 1 if tuple1 > tuple2 else -1
 
-    def __lt__(self, other: "_Version") -> bool:
+    def __lt__(self, other: _Version) -> bool:
         """
         Less than comparison operator.
 
@@ -893,7 +913,7 @@ def _canonical_minor_version(datasource: str, version: str) -> str:
     return version
 
 
-def _rebuild_repo_names(repo_data: "_TransversalStatusRepo") -> None:
+def _rebuild_repo_names(repo_data: _TransversalStatusRepo) -> None:
     """
     Rebuild the names index for a single repository.
 
@@ -921,7 +941,7 @@ def _rebuild_repo_names(repo_data: "_TransversalStatusRepo") -> None:
     repo_data.names_index = names_index
 
 
-def _rebuild_repo_dependencies(repo_data: "_TransversalStatusRepo") -> None:
+def _rebuild_repo_dependencies(repo_data: _TransversalStatusRepo) -> None:
     """Rebuild the per-repo dependency index used by reverse dependency lookups."""
     dependencies_index = _TransversalStatusDependenciesIndex()
     for branch, branch_data in repo_data.versions.items():
@@ -954,7 +974,7 @@ def _rebuild_repo_dependencies(repo_data: "_TransversalStatusRepo") -> None:
     repo_data.dependencies_index = dependencies_index
 
 
-def _build_global_names(transversal_status: "_TransversalStatus") -> _Names:
+def _build_global_names(transversal_status: _TransversalStatus) -> _Names:
     """
     Assemble the global names lookup from the per-repo persisted indices.
 
@@ -1470,15 +1490,7 @@ def _support_category(s: str, support_until: datetime.date | None = None) -> _Su
     return _SupportCategory.UNKNOWN  # Any other string
 
 
-def _support_value(value: str | _SupportType | _Support) -> str:
-    if isinstance(value, _Support):
-        return value.type.value
-    if isinstance(value, _SupportType):
-        return value.value
-    return value
-
-
-def _support_cmp(a: str | _SupportType | _Support, b: str | _SupportType | _Support) -> int:
+def _support_cmp(a: _Support, b: _Support) -> int:
     """
     Compare two support status strings.
 
@@ -1494,10 +1506,10 @@ def _support_cmp(a: str | _SupportType | _Support, b: str | _SupportType | _Supp
     """
 
     # Normalize once and use consistently for category and date parsing
-    a_norm = (_support_value(a) or "").strip()
-    b_norm = (_support_value(b) or "").strip()
-    a_until = a.until if isinstance(a, _Support) else None
-    b_until = b.until if isinstance(b, _Support) else None
+    a_norm = (a.type.value or "").strip()
+    b_norm = (b.type.value or "").strip()
+    a_until = a.until
+    b_until = b.until
 
     cat_a = _support_category(a_norm, a_until)
     cat_b = _support_category(b_norm, b_until)
@@ -1603,7 +1615,13 @@ def _build_internal_dependencies(
                         candidates = list(real_statuses or status_values)
                         support = candidates[0]
                         for other_support in candidates[1:]:
-                            if _support_cmp(other_support, support) < 0:
+                            if (
+                                _support_cmp(
+                                    _support_from_value(other_support),
+                                    _support_from_value(support),
+                                )
+                                < 0
+                            ):
                                 support = other_support
                 elif not dependency_package_data.has_security_policy:
                     support = dependency_package_data.status_by_version.get(
@@ -1631,7 +1649,7 @@ def _build_internal_dependencies(
                             if dependency_package_data.has_security_policy is False
                             or _is_supported(
                                 version_data.support,
-                                support,
+                                _support_from_value(support),
                             )
                             else _UNSUPPORTED_COLOR
                         ),
@@ -1828,7 +1846,13 @@ def _apply_additional_packages(
                     # Choose the "least" support (most restrictive)
                     min_support = supports[0]
                     for s in supports[1:]:
-                        if _support_cmp(s, min_support) < 0:
+                        if (
+                            _support_cmp(
+                                _support_from_value(s),
+                                _support_from_value(min_support),
+                            )
+                            < 0
+                        ):
                             min_support = s
                     version_data["support"] = min_support
                 else:

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -1490,13 +1490,11 @@ def _support_cmp(a: _Support, b: _Support) -> int:
     """
 
     # Normalize once and use consistently for category and date parsing
-    a_norm = (a.type.value or "").strip()
-    b_norm = (b.type.value or "").strip()
     a_until = a.until
     b_until = b.until
 
-    cat_a = _support_category(a_norm, a_until)
-    cat_b = _support_category(b_norm, b_until)
+    cat_a = _support_category(a.type.value, a_until)
+    cat_b = _support_category(b.type.value, b_until)
     if _SupportCategory.NO_SUPPORT_DEFINED in (cat_a, cat_b):
         # No support defined is considered equal to everything to never be in red
         return 0
@@ -1505,14 +1503,12 @@ def _support_cmp(a: _Support, b: _Support) -> int:
     if cat_a == _SupportCategory.DATE and cat_b == _SupportCategory.DATE:
         # Both are dates, compare as dates (oldest = less support)
         try:
-            da = a_until or _parse_support_date_value(a_norm)
-            db = b_until or _parse_support_date_value(b_norm)
-            if da is None or db is None:
+            if a_until is None or b_until is None:
                 message = f"Failed to parse support dates for comparison: {a!r}, {b!r}"
                 raise ValueError(message)  # noqa: TRY301
-            if da < db:
+            if a_until < b_until:
                 return -1
-            if da > db:
+            if a_until > b_until:
                 return 1
         except Exception:
             message = "Error parsing dates for support comparison: %s, %s"

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -63,22 +63,6 @@ def _support_display(support: _Support) -> str:
     return support.type.value
 
 
-def _support_from_value(value: str | _SupportType | _Support) -> _Support:
-    if isinstance(value, _Support):
-        return value
-    if isinstance(value, _SupportType):
-        return _Support(type=value)
-    normalized = value.strip()
-    parsed_date = _parse_support_date_value(normalized)
-    if parsed_date is not None:
-        return _Support(type=_SupportType.DATE, until=parsed_date)
-    lowered = normalized.lower()
-    for support_type in _SupportType:
-        if support_type.value.lower() == lowered:
-            return _Support(type=support_type)
-    return _Support(type=_SupportType.UNKNOWN)
-
-
 class _TransversalStatusNameByDatasource(BaseModel):
     names: list[str] = []
 
@@ -110,7 +94,7 @@ class _TransversalStatusDependenciesIndex(BaseModel):
 class _TransversalStatusNamesByVersion(BaseModel):
     """Map canonical version -> support status for a package."""
 
-    by_version: dict[str, str] = {}
+    by_version: dict[str, _Support] = {}
 
     @model_validator(mode="before")
     @classmethod
@@ -119,9 +103,17 @@ class _TransversalStatusNamesByVersion(BaseModel):
             return {"by_version": data}
         return data
 
+    @model_validator(mode="after")
+    def _normalize_supports(self) -> _TransversalStatusNamesByVersion:
+        self.by_version = {
+            key: value if isinstance(value, _Support) else _Support.model_validate(value)
+            for key, value in self.by_version.items()
+        }
+        return self
+
     @model_serializer(mode="plain")
-    def _to_flat(self) -> dict[str, str]:
-        return self.by_version
+    def _to_flat(self) -> dict[str, Any]:
+        return {key: _support_display(value) for key, value in self.by_version.items()}
 
 
 class _TransversalStatusNamesByPackage(BaseModel):
@@ -176,10 +168,15 @@ class _Support(BaseModel):
             parsed_date = _parse_support_date_value(data)
             if parsed_date is not None:
                 return {"type": _SupportType.DATE, "until": parsed_date}
-            try:
-                return {"type": _SupportType(data)}
-            except ValueError:
-                return {"type": _SupportType.UNKNOWN}
+            for support_type in _SupportType:
+                if support_type.value.lower() == data.lower():
+                    return {"type": support_type}
+            return {"type": _SupportType.UNKNOWN}
+        if isinstance(data, dict) and data.get("type") == "Date":
+            return {
+                "type": _SupportType.DATE,
+                "until": data.get("until"),
+            }
         if isinstance(data, dict) and "type" in data:
             support_type = data.get("type")
             if isinstance(support_type, str):
@@ -228,7 +225,7 @@ class _TransversalStatusRepo(BaseModel):
 
 
 class _NamesStatus(BaseModel):
-    status_by_version: dict[str, str] = {}
+    status_by_version: dict[str, _Support] = {}
     repo: str | None = None
     has_security_policy: bool = False
 
@@ -254,7 +251,7 @@ class _IntermediateStatus(BaseModel):
     version: str | None = None
     url: str | None = None
     has_security_policy: bool = False
-    version_support: dict[str, str] = {}
+    version_support: dict[str, _Support] = {}
     version_names_by_datasource: dict[str, _TransversalStatusNameByDatasource] = {}
     version_dependencies_by_datasource: dict[
         str,
@@ -280,6 +277,8 @@ class _DependencyBase(BaseModel):
                 data = {**data, "support": _support_display(value)}
             elif isinstance(value, dict):
                 data = {**data, "support": _support_display(_Support(**value))}
+            elif isinstance(value, _SupportType):
+                data = {**data, "support": value.value}
         return data
 
 
@@ -441,7 +440,9 @@ class Versions(
             stabilization_versions.append(default_branch)
             _LOGGER.debug("Versions: %s", ", ".join(stabilization_versions))
             for version in stabilization_versions:
-                intermediate_status.version_support[version] = _SupportType.BEST_EFFORT.value
+                intermediate_status.version_support[version] = _Support(
+                    type=_SupportType.BEST_EFFORT,
+                )
 
             if security is not None:
                 version_index = security.version_index
@@ -451,7 +452,7 @@ class Versions(
                         version = raw[version_index]
                         support = raw[support_index]
                         if version in intermediate_status.version_support:
-                            intermediate_status.version_support[version] = support
+                            intermediate_status.version_support[version] = _Support(type=support)
 
             intermediate_status.stabilization_versions = stabilization_versions
 
@@ -621,9 +622,9 @@ class Versions(
             for version_name, support in intermediate_status.version_support.items():
                 version = repo.versions.setdefault(
                     version_name,
-                    _TransversalStatusVersion(support=_Support(type=support)),
+                    _TransversalStatusVersion(support=support),
                 )
-                version.support = _Support(type=support)
+                version.support = support
 
             if intermediate_status.stabilization_versions:
                 for version_name in list(versions.keys()):
@@ -935,9 +936,7 @@ def _rebuild_repo_names(repo_data: _TransversalStatusRepo) -> None:
                 ).by_package.setdefault(
                     name,
                     _TransversalStatusNamesByVersion(),
-                ).by_version[_canonical_minor_version(datasource, branch)] = _support_display(
-                    branch_data.support,
-                )
+                ).by_version[_canonical_minor_version(datasource, branch)] = branch_data.support
     repo_data.names_index = names_index
 
 
@@ -1452,6 +1451,8 @@ async def _update_upstream_versions(
 
 
 def _parse_support_date(text: str) -> datetime.datetime | None:
+    if not isinstance(text, str):
+        return None
     # Try ISO and DD/MM/YYYY date formats
     try:
         date = datetime.datetime.fromisoformat(text)
@@ -1476,7 +1477,9 @@ def _parse_support_date_value(text: str) -> datetime.date | None:
 
 
 def _support_category(s: str, support_until: datetime.date | None = None) -> _SupportCategory:
-    s = (s or "").strip().lower()
+    if not isinstance(s, str):
+        s = ""
+    s = s.strip().lower()
     if s == _SupportType.NO_SUPPORT_DEFINED.value.lower():
         return _SupportCategory.NO_SUPPORT_DEFINED
     if s == _SupportType.UNSUPPORTED.value.lower():
@@ -1605,20 +1608,20 @@ def _build_internal_dependencies(
                     dependency_version,
                 )
                 if datasource_name == "docker":
-                    status_values = set(dependency_package_data.status_by_version.values())
+                    status_values = list(dependency_package_data.status_by_version.values())
                     if not status_values:
-                        support = _SupportType.NO_SUPPORT_DEFINED.value
+                        support = _Support(type=_SupportType.NO_SUPPORT_DEFINED)
                     else:
-                        real_statuses = {
-                            s for s in status_values if s != _SupportType.NO_SUPPORT_DEFINED.value
-                        }
-                        candidates = list(real_statuses or status_values)
+                        real_statuses = [
+                            s for s in status_values if s.type != _SupportType.NO_SUPPORT_DEFINED
+                        ]
+                        candidates = real_statuses or status_values
                         support = candidates[0]
                         for other_support in candidates[1:]:
                             if (
                                 _support_cmp(
-                                    _support_from_value(other_support),
-                                    _support_from_value(support),
+                                    other_support,
+                                    support,
                                 )
                                 < 0
                             ):
@@ -1626,12 +1629,12 @@ def _build_internal_dependencies(
                 elif not dependency_package_data.has_security_policy:
                     support = dependency_package_data.status_by_version.get(
                         dependency_minor,
-                        _SupportType.NO_SUPPORT_DEFINED.value,
+                        _Support(type=_SupportType.NO_SUPPORT_DEFINED),
                     )
                 else:
                     support = dependency_package_data.status_by_version.get(
                         dependency_minor,
-                        _SupportType.UNSUPPORTED.value,
+                        _Support(type=_SupportType.UNSUPPORTED),
                     )
                 clean_dependency_version = _clean_version(dependency_version)
                 dependencies_branch.forward.append(
@@ -1649,7 +1652,7 @@ def _build_internal_dependencies(
                             if dependency_package_data.has_security_policy is False
                             or _is_supported(
                                 version_data.support,
-                                _support_from_value(support),
+                                support,
                             )
                             else _UNSUPPORTED_COLOR
                         ),
@@ -1784,7 +1787,7 @@ def _apply_additional_packages(
     # (datasource_name, package_name, normalized_version) -> list[support]
     # The normalized version is computed per datasource (docker uses the full version,
     # others use the canonical major.minor form).
-    support_index: dict[tuple[str, str, str], list[str]] = {}
+    support_index: dict[tuple[str, str, str], list[_Support]] = {}
     for other_repo_data in transversal_status.repositories.values():
         for other_version, other_version_data in other_repo_data.versions.items():
             cleaned_other_version = _clean_version(other_version)
@@ -1795,7 +1798,7 @@ def _apply_additional_packages(
                 for name in other_name.names:
                     support_index.setdefault(
                         (other_datasource_name, name, normalized_other_version), []
-                    ).append(_support_display(other_version_data.support))
+                    ).append(other_version_data.support)
 
     for repo, data in context.module_config.get("additional-packages", {}).items():
         module_utils.manage_updated_separated(
@@ -1813,10 +1816,10 @@ def _apply_additional_packages(
                     continue
                 deps_by_datasource = version_data.get("dependencies_by_datasource")
                 if not isinstance(deps_by_datasource, dict):
-                    version_data["support"] = _SupportType.NO_SUPPORT_DEFINED.value
+                    version_data["support"] = _Support(type=_SupportType.NO_SUPPORT_DEFINED)
                     continue
                 # Gather all dependency supports using the pre-built index
-                supports = []
+                supports: list[_Support] = []
                 for dep_datasource_name, dep_datasource in deps_by_datasource.items():
                     if not isinstance(dep_datasource, dict):
                         continue
@@ -1846,24 +1849,18 @@ def _apply_additional_packages(
                     # Choose the "least" support (most restrictive)
                     min_support = supports[0]
                     for s in supports[1:]:
-                        if (
-                            _support_cmp(
-                                _support_from_value(s),
-                                _support_from_value(min_support),
-                            )
-                            < 0
-                        ):
+                        if _support_cmp(s, min_support) < 0:
                             min_support = s
                     version_data["support"] = min_support
                 else:
-                    version_data["support"] = _SupportType.UNSUPPORTED.value
+                    version_data["support"] = _Support(type=_SupportType.UNSUPPORTED)
 
         if isinstance(data, dict):
             versions = data.get("versions")
             if isinstance(versions, dict):
                 for version_data in versions.values():
                     if isinstance(version_data, dict) and "support" not in version_data:
-                        version_data["support"] = _SupportType.NO_SUPPORT_DEFINED.value
+                        version_data["support"] = _Support(type=_SupportType.NO_SUPPORT_DEFINED)
 
         pydentic_data = _TransversalStatusRepo(**data)
         _rebuild_repo_names(pydentic_data)

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -1470,9 +1470,15 @@ def _support_category(s: str, support_until: datetime.date | None = None) -> _Su
     return _SupportCategory.UNKNOWN  # Any other string
 
 
+def _support_value(value: str | _SupportType) -> str:
+    if isinstance(value, _SupportType):
+        return value.value
+    return value
+
+
 def _support_cmp(
-    a: str,
-    b: str,
+    a: str | _SupportType,
+    b: str | _SupportType,
     a_support_until: datetime.date | None = None,
     b_support_until: datetime.date | None = None,
 ) -> int:
@@ -1491,8 +1497,8 @@ def _support_cmp(
     """
 
     # Normalize once and use consistently for category and date parsing
-    a_norm = (a or "").strip()
-    b_norm = (b or "").strip()
+    a_norm = (_support_value(a) or "").strip()
+    b_norm = (_support_value(b) or "").strip()
 
     cat_a = _support_category(a_norm, a_support_until)
     cat_b = _support_category(b_norm, b_support_until)
@@ -1521,8 +1527,8 @@ def _support_cmp(
 
 
 def _is_supported(
-    base: str,
-    other: str,
+    base: str | _SupportType,
+    other: str | _SupportType,
     base_support_until: datetime.date | None = None,
     other_support_until: datetime.date | None = None,
 ) -> bool:

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -1632,7 +1632,11 @@ def _build_reverse_dependency(
                                     name=other_repo,
                                     version=_clean_version(other_version),
                                     support=other_version_data.support,
-                                    color=_UNSUPPORTED_COLOR,
+                                    color=(
+                                        _SUPPORTED_COLOR
+                                        if not repo_data.has_security_policy
+                                        else _UNSUPPORTED_COLOR
+                                    ),
                                     repo=other_repo,
                                 ),
                             )

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -14,7 +14,7 @@ import tempfile
 import tomllib
 from enum import Enum, IntEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 import anyio
@@ -55,12 +55,6 @@ class _SupportType(Enum):
     TO_BE_DEFINED = "To be defined"
     DATE = "Date"
     UNKNOWN = "Unknown"
-
-
-def _support_display(support: _Support) -> str:
-    if support.type == _SupportType.DATE and support.until is not None:
-        return support.until.strftime("%d/%m/%Y")
-    return support.type.value
 
 
 class _TransversalStatusNameByDatasource(BaseModel):
@@ -106,7 +100,7 @@ class _TransversalStatusNamesByVersion(BaseModel):
     @model_validator(mode="after")
     def _normalize_supports(self) -> _TransversalStatusNamesByVersion:
         self.by_version = {
-            key: value if isinstance(value, _Support) else _Support.model_validate(value)
+            key: value if isinstance(value, _Support) else _Support(type=_SupportType(value))
             for key, value in self.by_version.items()
         }
         return self
@@ -156,23 +150,25 @@ class _Support(BaseModel):
         if isinstance(data, dict) and data.get("type") == "Date":
             return {
                 "type": _SupportType.DATE,
-                "until": data.get("until"),
+                "until": cast("datetime.date | None", data.get("until")),
             }
         if isinstance(data, dict) and "type" in data:
-            support_type = data.get("type")
-            if isinstance(support_type, str):
-                parsed_date = _parse_support_date_value(support_type)
+            raw_type = data.get("type")
+            if raw_type is None:
+                return {**data, "type": _SupportType.UNKNOWN}
+            if isinstance(raw_type, str):
+                parsed_date = _parse_support_date_value(raw_type)
                 if parsed_date is not None:
-                    data = {
+                    return {
                         **data,
                         "type": _SupportType.DATE,
                         "until": data.get("until") or parsed_date,
                     }
-                else:
-                    try:
-                        data = {**data, "type": _SupportType(support_type)}
-                    except ValueError:
-                        data = {**data, "type": _SupportType.UNKNOWN}
+                try:
+                    return {**data, "type": _SupportType(raw_type)}
+                except ValueError:
+                    return {**data, "type": _SupportType.UNKNOWN}
+            return {**data, "type": _SupportType.UNKNOWN}
         return data
 
     @model_validator(mode="after")
@@ -245,22 +241,15 @@ class _IntermediateStatus(BaseModel):
 class _DependencyBase(BaseModel):
     name: str
     version: str
-    support: str
+    support: _Support
     color: str
     repo: str
 
-    @model_validator(mode="before")
-    @classmethod
-    def _normalize_support(cls, data: Any) -> Any:
-        if isinstance(data, dict) and "support" in data:
-            value = data.get("support")
-            if isinstance(value, _Support):
-                data = {**data, "support": _support_display(value)}
-            elif isinstance(value, dict):
-                data = {**data, "support": _support_display(_Support(**value))}
-            elif isinstance(value, _SupportType):
-                data = {**data, "support": value.value}
-        return data
+    @property
+    def support_display(self) -> str:
+        if self.support.type == _SupportType.DATE and self.support.until is not None:
+            return self.support.until.strftime("%d/%m/%Y")
+        return self.support.type.value
 
 
 class _Dependency(_DependencyBase):
@@ -433,7 +422,9 @@ class Versions(
                         version = raw[version_index]
                         support = raw[support_index]
                         if version in intermediate_status.version_support:
-                            intermediate_status.version_support[version] = _Support(type=support)
+                            intermediate_status.version_support[version] = _Support(
+                                type=_SupportType(support)
+                            )
 
             intermediate_status.stabilization_versions = stabilization_versions
 
@@ -1422,7 +1413,7 @@ async def _update_upstream_versions(
                 support_until = parsed_eol.astimezone(datetime.UTC).date()
                 eol = parsed_eol.astimezone(datetime.UTC).strftime("%d/%m/%Y")
             package_status.versions[cycle["cycle"]] = _TransversalStatusVersion(
-                support=_Support(type=eol, until=support_until),
+                support=_Support(type=_SupportType(eol), until=support_until),
                 names_by_datasource={
                     datasource: _TransversalStatusNameByDatasource(
                         names=[package],
@@ -1696,7 +1687,7 @@ def _build_reverse_dependency(
                                 _DependencyReverse(
                                     name=other_repo,
                                     version=_clean_version(other_version),
-                                    support=_support_display(other_version_data.support),
+                                    support=other_version_data.support,
                                     color=(
                                         _SUPPORTED_COLOR
                                         if _is_supported(
@@ -1729,7 +1720,7 @@ def _build_reverse_dependency(
                                 _DependencyReverse(
                                     name=other_repo,
                                     version=_clean_version(other_version),
-                                    support=_support_display(other_version_data.support),
+                                    support=other_version_data.support,
                                     color=(
                                         _SUPPORTED_COLOR
                                         if not repo_data.has_security_policy

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -11,7 +11,7 @@ import re
 import tempfile
 import tomllib
 from collections.abc import Iterable
-from enum import IntEnum
+from enum import Enum, IntEnum
 from pathlib import Path
 from typing import Any
 
@@ -46,6 +46,15 @@ class _SupportCategory(IntEnum):
     TO_BE_DEFINED = 3
     DATE = 4
     UNKNOWN = -1
+
+
+class _SupportType(Enum):
+    NO_SUPPORT_DEFINED = _NO_SUPPORT_DEFINED
+    UNSUPPORTED = _UNSUPPORTED
+    BEST_EFFORT = _BEST_EFFORT
+    TO_BE_DEFINED = _TO_BE_DEFINED
+    DATE = "Date"
+    UNKNOWN = "Unknown"
 
 
 class _TransversalStatusNameByDatasource(BaseModel):
@@ -128,12 +137,12 @@ class _TransversalStatusNamesIndex(BaseModel):
 
 
 class _Support(BaseModel):
-    type: str = _NO_SUPPORT_DEFINED
+    type: _SupportType = _SupportType.NO_SUPPORT_DEFINED
     until: datetime.date | None = None
 
     @model_serializer(mode="plain")
     def _to_plain(self) -> dict[str, Any]:
-        data: dict[str, Any] = {"type": self.type}
+        data: dict[str, Any] = {"type": self.type.value}
         if self.until is not None:
             data["until"] = self.until
         return data
@@ -142,13 +151,34 @@ class _Support(BaseModel):
     @classmethod
     def _from_str(cls, data: Any) -> Any:
         if isinstance(data, str):
-            return {"type": data}
+            parsed_date = _parse_support_date_value(data)
+            if parsed_date is not None:
+                return {"type": _SupportType.DATE, "until": parsed_date}
+            try:
+                return {"type": _SupportType(data)}
+            except ValueError:
+                return {"type": _SupportType.UNKNOWN}
+        if isinstance(data, dict) and "type" in data:
+            support_type = data.get("type")
+            if isinstance(support_type, str):
+                parsed_date = _parse_support_date_value(support_type)
+                if parsed_date is not None:
+                    data = {
+                        **data,
+                        "type": _SupportType.DATE,
+                        "until": data.get("until") or parsed_date,
+                    }
+                else:
+                    try:
+                        data = {**data, "type": _SupportType(support_type)}
+                    except ValueError:
+                        data = {**data, "type": _SupportType.UNKNOWN}
         return data
 
     @model_validator(mode="after")
     def _set_until_from_type(self) -> "_Support":
-        if self.until is None:
-            self.until = _parse_support_date_value(self.type)
+        if self.until is None and self.type not in (_SupportType.DATE, _SupportType.UNKNOWN):
+            self.until = _parse_support_date_value(str(self.type.value))
         return self
 
 
@@ -1587,7 +1617,7 @@ def _build_internal_dependencies(
                             _SUPPORTED_COLOR
                             if dependency_package_data.has_security_policy is False
                             or _is_supported(
-                                version_data.support.type,
+                                version_data.support.type.value,
                                 support,
                                 base_support_until=version_data.support.until,
                             )
@@ -1660,12 +1690,12 @@ def _build_reverse_dependency(
                                 _DependencyReverse(
                                     name=other_repo,
                                     version=_clean_version(other_version),
-                                    support=other_version_data.support.type,
+                                    support=other_version_data.support.type.value,
                                     color=(
                                         _SUPPORTED_COLOR
                                         if _is_supported(
-                                            other_version_data.support.type,
-                                            version_data.support.type,
+                                            other_version_data.support.type.value,
+                                            version_data.support.type.value,
                                             base_support_until=other_version_data.support.until,
                                             other_support_until=version_data.support.until,
                                         )
@@ -1695,7 +1725,7 @@ def _build_reverse_dependency(
                                 _DependencyReverse(
                                     name=other_repo,
                                     version=_clean_version(other_version),
-                                    support=other_version_data.support.type,
+                                    support=other_version_data.support.type.value,
                                     color=(
                                         _SUPPORTED_COLOR
                                         if not repo_data.has_security_policy
@@ -1737,7 +1767,7 @@ def _apply_additional_packages(
                 for name in other_name.names:
                     support_index.setdefault(
                         (other_datasource_name, name, normalized_other_version), []
-                    ).append(other_version_data.support.type)
+                    ).append(other_version_data.support.type.value)
 
     for repo, data in context.module_config.get("additional-packages", {}).items():
         module_utils.manage_updated_separated(

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -1489,12 +1489,8 @@ def _support_cmp(a: _Support, b: _Support) -> int:
     Older dates are considered less supported.
     """
 
-    # Normalize once and use consistently for category and date parsing
-    a_until = a.until
-    b_until = b.until
-
-    cat_a = _support_category(a.type.value, a_until)
-    cat_b = _support_category(b.type.value, b_until)
+    cat_a = _support_category(a.type.value, a.until)
+    cat_b = _support_category(b.type.value, b.until)
     if _SupportCategory.NO_SUPPORT_DEFINED in (cat_a, cat_b):
         # No support defined is considered equal to everything to never be in red
         return 0
@@ -1503,12 +1499,12 @@ def _support_cmp(a: _Support, b: _Support) -> int:
     if cat_a == _SupportCategory.DATE and cat_b == _SupportCategory.DATE:
         # Both are dates, compare as dates (oldest = less support)
         try:
-            if a_until is None or b_until is None:
+            if a.until is None or b.until is None:
                 message = f"Failed to parse support dates for comparison: {a!r}, {b!r}"
                 raise ValueError(message)  # noqa: TRY301
-            if a_until < b_until:
+            if a.until < b.until:
                 return -1
-            if a_until > b_until:
+            if a.until > b.until:
                 return 1
         except Exception:
             message = "Error parsing dates for support comparison: %s, %s"

--- a/github_app_geo_project/module/versions/repository.html
+++ b/github_app_geo_project/module/versions/repository.html
@@ -12,7 +12,7 @@
 <!---->
 <% dependencies = dependencies_branches.by_branch[branch] %>
 <h3>${branch}</h3>
-<p style="background-color: var(${dependencies.color})">Supported: ${dependencies.support}</p>
+<p style="background-color: var(${dependencies.color})">Supported: ${dependencies.support.type}</p>
 %if dependencies.forward:
 <h4>Internal dependencies</h4>
 <table>

--- a/github_app_geo_project/module/versions/repository.html
+++ b/github_app_geo_project/module/versions/repository.html
@@ -12,7 +12,7 @@
 <!---->
 <% dependencies = dependencies_branches.by_branch[branch] %>
 <h3>${branch}</h3>
-<p style="background-color: var(${dependencies.color})">Supported: ${dependencies.support}</p>
+<p style="background-color: var(${dependencies.color})">Supported: ${dependencies.support_display}</p>
 %if dependencies.forward:
 <h4>Internal dependencies</h4>
 <table>
@@ -27,7 +27,7 @@
     <td><a href="?repository=${dependency.repo}">${dependency.name}</a></td>
     <td>${dependency.datasource}</td>
     <td>${dependency.version}</td>
-    <td style="background-color: var(${dependency.color})">${dependency.support}</td>
+    <td style="background-color: var(${dependency.color})">${dependency.support_display}</td>
   </tr>
   %endfor
 </table>
@@ -45,7 +45,7 @@
   <tr>
     <td><a href="?repository=${dependency.repo}">${dependency.name}</a></td>
     <td>${dependency.version}</td>
-    <td style="background-color: var(${dependency.color})">${dependency.support}</td>
+    <td style="background-color: var(${dependency.color})">${dependency.support_display}</td>
   </tr>
   %endfor
 </table>

--- a/github_app_geo_project/module/versions/repository.html
+++ b/github_app_geo_project/module/versions/repository.html
@@ -12,7 +12,7 @@
 <!---->
 <% dependencies = dependencies_branches.by_branch[branch] %>
 <h3>${branch}</h3>
-<p style="background-color: var(${dependencies.color})">Supported: ${dependencies.support.type}</p>
+<p style="background-color: var(${dependencies.color})">Supported: ${dependencies.support}</p>
 %if dependencies.forward:
 <h4>Internal dependencies</h4>
 <table>

--- a/github_app_geo_project/module/versions/repository.html
+++ b/github_app_geo_project/module/versions/repository.html
@@ -12,7 +12,7 @@
 <!---->
 <% dependencies = dependencies_branches.by_branch[branch] %>
 <h3>${branch}</h3>
-<p style="background-color: var(${dependencies.color})">Supported: ${dependencies.support_display}</p>
+<p style="background-color: var(${dependencies.color})">Supported: ${dependencies.support.display}</p>
 %if dependencies.forward:
 <h4>Internal dependencies</h4>
 <table>
@@ -27,7 +27,7 @@
     <td><a href="?repository=${dependency.repo}">${dependency.name}</a></td>
     <td>${dependency.datasource}</td>
     <td>${dependency.version}</td>
-    <td style="background-color: var(${dependency.color})">${dependency.support_display}</td>
+    <td style="background-color: var(${dependency.color})">${dependency.support.display}</td>
   </tr>
   %endfor
 </table>
@@ -45,7 +45,7 @@
   <tr>
     <td><a href="?repository=${dependency.repo}">${dependency.name}</a></td>
     <td>${dependency.version}</td>
-    <td style="background-color: var(${dependency.color})">${dependency.support_display}</td>
+    <td style="background-color: var(${dependency.color})">${dependency.support.display}</td>
   </tr>
   %endfor
 </table>

--- a/tests/test_module_versions.py
+++ b/tests/test_module_versions.py
@@ -25,6 +25,7 @@ from github_app_geo_project.module.versions import (
     _support_category,
     _support_cmp,
     _SupportCategory,
+    _SupportType,
     _TransversalStatus,
     _TransversalStatusDependenciesIndex,
     _TransversalStatusNameByDatasource,
@@ -1984,6 +1985,16 @@ def test_support_category(value, expected):
 )
 def test_support_cmp(a, b, expected):
     assert _support_cmp(a, b) == expected
+
+
+def test_support_cmp_enum() -> None:
+    assert _support_cmp(_SupportType.BEST_EFFORT, _SupportType.UNSUPPORTED) == 1
+    assert _support_cmp(_SupportType.UNSUPPORTED, _SupportType.BEST_EFFORT) == -1
+
+
+def test_is_supported_enum() -> None:
+    assert _is_supported(_SupportType.BEST_EFFORT, _SupportType.UNSUPPORTED) is False
+    assert _is_supported(_SupportType.UNSUPPORTED, _SupportType.BEST_EFFORT) is True
 
 
 def test_apply_additional_packages_least_support():

--- a/tests/test_module_versions.py
+++ b/tests/test_module_versions.py
@@ -22,9 +22,9 @@ from github_app_geo_project.module.versions import (
     _parse_support_date,
     _read_dependencies,
     _rebuild_repo_dependencies,
-    _Support,
     _support_category,
     _support_cmp,
+    _support_from_value,
     _SupportCategory,
     _SupportType,
     _TransversalStatus,
@@ -1919,7 +1919,13 @@ def test_build_reverse_dependency_uses_dependencies_index_docker() -> None:
     ],
 )
 def test_is_supported(support, dependency_support, expected_result):
-    assert _is_supported(support, dependency_support) == expected_result
+    assert (
+        _is_supported(
+            _support_from_value(support),
+            _support_from_value(dependency_support),
+        )
+        == expected_result
+    )
 
 
 @pytest.mark.parametrize(
@@ -1985,26 +1991,38 @@ def test_support_category(value, expected):
     ],
 )
 def test_support_cmp(a, b, expected):
-    assert _support_cmp(a, b) == expected
+    assert _support_cmp(_support_from_value(a), _support_from_value(b)) == expected
 
 
 def test_support_cmp_enum() -> None:
-    assert _support_cmp(_SupportType.BEST_EFFORT, _SupportType.UNSUPPORTED) == 1
-    assert _support_cmp(_SupportType.UNSUPPORTED, _SupportType.BEST_EFFORT) == -1
+    assert (
+        _support_cmp(
+            _support_from_value(_SupportType.BEST_EFFORT),
+            _support_from_value(_SupportType.UNSUPPORTED),
+        )
+        == 1
+    )
+    assert (
+        _support_cmp(
+            _support_from_value(_SupportType.UNSUPPORTED),
+            _support_from_value(_SupportType.BEST_EFFORT),
+        )
+        == -1
+    )
 
 
 def test_is_supported_enum() -> None:
     assert (
         _is_supported(
-            _Support(type=_SupportType.BEST_EFFORT),
-            _Support(type=_SupportType.UNSUPPORTED),
+            _support_from_value(_SupportType.BEST_EFFORT),
+            _support_from_value(_SupportType.UNSUPPORTED),
         )
         is False
     )
     assert (
         _is_supported(
-            _Support(type=_SupportType.UNSUPPORTED),
-            _Support(type=_SupportType.BEST_EFFORT),
+            _support_from_value(_SupportType.UNSUPPORTED),
+            _support_from_value(_SupportType.BEST_EFFORT),
         )
         is True
     )

--- a/tests/test_module_versions.py
+++ b/tests/test_module_versions.py
@@ -294,7 +294,7 @@ def test_get_transversal_dashboard_repo_forward(other_support: str, expected_col
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
+                        support={"type": "Date", "until": datetime.date(2045, 1, 1)},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -330,7 +330,7 @@ def test_get_transversal_dashboard_repo_forward(other_support: str, expected_col
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
+                support={"type": "Date", "until": datetime.date(2045, 1, 1)},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
@@ -420,7 +420,7 @@ def test_get_transversal_dashboard_repo_forward_docker_2() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "27/06/2027", "until": datetime.date(2027, 6, 27)},
+                        support={"type": "Date", "until": datetime.date(2027, 6, 27)},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -466,7 +466,7 @@ def test_get_transversal_dashboard_repo_forward_docker_2() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "27/06/2027", "until": datetime.date(2027, 6, 27)},
+                support={"type": "Date", "until": datetime.date(2027, 6, 27)},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
@@ -577,7 +577,7 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "27/06/2027", "until": datetime.date(2027, 6, 27)},
+                        support={"type": "Date", "until": datetime.date(2027, 6, 27)},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -624,7 +624,7 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "27/06/2027", "until": datetime.date(2027, 6, 27)},
+                support={"type": "Date", "until": datetime.date(2027, 6, 27)},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
@@ -655,7 +655,7 @@ def test_get_transversal_dashboard_repo_forward_docker_empty_status() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "27/06/2027", "until": datetime.date(2027, 6, 27)},
+                        support={"type": "Date", "until": datetime.date(2027, 6, 27)},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -681,7 +681,7 @@ def test_get_transversal_dashboard_repo_forward_docker_empty_status() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "27/06/2027", "until": datetime.date(2027, 6, 27)},
+                support={"type": "Date", "until": datetime.date(2027, 6, 27)},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
@@ -771,7 +771,7 @@ def test_get_transversal_dashboard_repo_forward_no_support() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
+                        support={"type": "Date", "until": datetime.date(2045, 1, 1)},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -807,7 +807,7 @@ def test_get_transversal_dashboard_repo_forward_no_support() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
+                support={"type": "Date", "until": datetime.date(2045, 1, 1)},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
@@ -834,7 +834,7 @@ def test_get_transversal_dashboard_repo_forward_no_support_version() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
+                        support={"type": "Date", "until": datetime.date(2045, 1, 1)},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -856,7 +856,7 @@ def test_get_transversal_dashboard_repo_forward_no_support_version() -> None:
                 },
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
+                        support={"type": "Date", "until": datetime.date(2045, 1, 1)},
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["other_package"]),
                         },
@@ -870,7 +870,7 @@ def test_get_transversal_dashboard_repo_forward_no_support_version() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
+                support={"type": "Date", "until": datetime.date(2045, 1, 1)},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
@@ -897,7 +897,7 @@ def test_get_transversal_dashboard_repo_forward_no_package() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
+                        support={"type": "Date", "until": datetime.date(2045, 1, 1)},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -915,7 +915,7 @@ def test_get_transversal_dashboard_repo_forward_no_package() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
+                support={"type": "Date", "until": datetime.date(2045, 1, 1)},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[],
@@ -937,7 +937,7 @@ def test_get_transversal_dashboard_repo_reverse(other_support: str, expected_col
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
+                        support={"type": "Date", "until": datetime.date(2045, 1, 1)},
                         names_by_datasource={"pypi": _TransversalStatusNameByDatasource(names=["test"])},
                     ),
                 },
@@ -963,7 +963,7 @@ def test_get_transversal_dashboard_repo_reverse(other_support: str, expected_col
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
+                support={"type": "Date", "until": datetime.date(2045, 1, 1)},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[

--- a/tests/test_module_versions.py
+++ b/tests/test_module_versions.py
@@ -157,7 +157,7 @@ DEBUG: Determining if we should process repository camptocamp/tilecloud, using G
                 "camptocamp/test": _TransversalStatusRepo(
                     versions={
                         "master": _TransversalStatusVersion(
-                            support="Best effort",
+                            support={"type": "Best effort"},
                         ),
                     },
                 ),
@@ -235,7 +235,7 @@ DEBUG: Determining if we should process repository camptocamp/tilecloud, using G
                             ],
                         },
                     },
-                    "support": "Best effort",
+                    "support": {"type": "Best effort"},
                 },
             },
         },
@@ -250,7 +250,7 @@ def test_get_transversal_dashboard() -> None:
             "camptocamp/test": _TransversalStatusRepo(
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -264,7 +264,7 @@ def test_get_transversal_dashboard() -> None:
             "camptocamp/other": _TransversalStatusRepo(
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["other_package"]),
                         },
@@ -294,7 +294,7 @@ def test_get_transversal_dashboard_repo_forward(other_support: str, expected_col
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="01/01/2045",
+                        support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -330,7 +330,7 @@ def test_get_transversal_dashboard_repo_forward(other_support: str, expected_col
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="01/01/2045",
+                support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
@@ -357,7 +357,7 @@ def test_get_transversal_dashboard_repo_forward_docker() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -379,7 +379,7 @@ def test_get_transversal_dashboard_repo_forward_docker() -> None:
                 },
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(names=["camptocamp/other:2.0"]),
                         },
@@ -393,14 +393,14 @@ def test_get_transversal_dashboard_repo_forward_docker() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="camptocamp/other",
                         datasource="docker",
                         version="2.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -420,7 +420,7 @@ def test_get_transversal_dashboard_repo_forward_docker_2() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="27/06/2027",
+                        support={"type": "27/06/2027", "until": datetime.date(2027, 6, 27)},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -447,7 +447,7 @@ def test_get_transversal_dashboard_repo_forward_docker_2() -> None:
                 },
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=[
@@ -466,14 +466,14 @@ def test_get_transversal_dashboard_repo_forward_docker_2() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="27/06/2027",
+                support={"type": "27/06/2027", "until": datetime.date(2027, 6, 27)},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="ghcr.io/osgeo/gdal",
                         datasource="docker",
                         version="ubuntu-small-3.8.5",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -493,7 +493,7 @@ def test_get_transversal_dashboard_repo_forward_docker_double() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -518,13 +518,13 @@ def test_get_transversal_dashboard_repo_forward_docker_double() -> None:
                 },
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(names=["camptocamp/other:1.0"]),
                         },
                     ),
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(names=["camptocamp/other:2.0"]),
                         },
@@ -538,14 +538,14 @@ def test_get_transversal_dashboard_repo_forward_docker_double() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="camptocamp/other",
                         datasource="docker",
                         version="1.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -553,7 +553,7 @@ def test_get_transversal_dashboard_repo_forward_docker_double() -> None:
                         name="camptocamp/other",
                         datasource="docker",
                         version="2.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -577,7 +577,7 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="27/06/2027",
+                        support={"type": "27/06/2027", "until": datetime.date(2027, 6, 27)},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -600,7 +600,7 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
                 },
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=["camptocamp/other:latest"],
@@ -608,7 +608,7 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
                         },
                     ),
                     "2.0": _TransversalStatusVersion(
-                        support="Unsupported",
+                        support={"type": "Unsupported"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=["camptocamp/other:latest"],
@@ -624,14 +624,14 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="27/06/2027",
+                support={"type": "27/06/2027", "until": datetime.date(2027, 6, 27)},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="camptocamp/other",
                         datasource="docker",
                         version="latest",
-                        support="Unsupported",
+                        support={"type": "Unsupported"},
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -655,7 +655,7 @@ def test_get_transversal_dashboard_repo_forward_docker_empty_status() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="27/06/2027",
+                        support={"type": "27/06/2027", "until": datetime.date(2027, 6, 27)},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -681,14 +681,14 @@ def test_get_transversal_dashboard_repo_forward_docker_empty_status() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="27/06/2027",
+                support={"type": "27/06/2027", "until": datetime.date(2027, 6, 27)},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="camptocamp/other",
                         datasource="docker",
                         version="latest",
-                        support="No support defined",
+                        support={"type": "No support defined"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -708,7 +708,7 @@ def test_get_transversal_dashboard_repo_forward_inexisting() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -730,7 +730,7 @@ def test_get_transversal_dashboard_repo_forward_inexisting() -> None:
                 },
                 versions={
                     "3.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["other_package"]),
                         },
@@ -744,14 +744,14 @@ def test_get_transversal_dashboard_repo_forward_inexisting() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="other_package",
                         datasource="pypi",
                         version="2.0 (2.0.1)",
-                        support="Unsupported",
+                        support={"type": "Unsupported"},
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -771,7 +771,7 @@ def test_get_transversal_dashboard_repo_forward_no_support() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="01/01/2045",
+                        support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -793,7 +793,7 @@ def test_get_transversal_dashboard_repo_forward_no_support() -> None:
                 },
                 versions={
                     "master": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["other_package"]),
                         },
@@ -807,14 +807,14 @@ def test_get_transversal_dashboard_repo_forward_no_support() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="01/01/2045",
+                support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="other_package",
                         datasource="pypi",
                         version="2.0 (2.0.1)",
-                        support="No support defined",
+                        support={"type": "No support defined"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -834,7 +834,7 @@ def test_get_transversal_dashboard_repo_forward_no_support_version() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="01/01/2045",
+                        support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -856,7 +856,7 @@ def test_get_transversal_dashboard_repo_forward_no_support_version() -> None:
                 },
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="01/01/2045",
+                        support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["other_package"]),
                         },
@@ -870,14 +870,14 @@ def test_get_transversal_dashboard_repo_forward_no_support_version() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="01/01/2045",
+                support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="other_package",
                         datasource="pypi",
                         version="2.0 (2.0.1)",
-                        support="Unsupported",
+                        support={"type": "Unsupported"},
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -897,7 +897,7 @@ def test_get_transversal_dashboard_repo_forward_no_package() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="01/01/2045",
+                        support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -915,7 +915,7 @@ def test_get_transversal_dashboard_repo_forward_no_package() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="01/01/2045",
+                support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[],
@@ -937,7 +937,7 @@ def test_get_transversal_dashboard_repo_reverse(other_support: str, expected_col
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="01/01/2045",
+                        support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
                         names_by_datasource={"pypi": _TransversalStatusNameByDatasource(names=["test"])},
                     ),
                 },
@@ -963,7 +963,7 @@ def test_get_transversal_dashboard_repo_reverse(other_support: str, expected_col
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="01/01/2045",
+                support={"type": "01/01/2045", "until": datetime.date(2045, 1, 1)},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[
@@ -989,7 +989,7 @@ def test_get_transversal_dashboard_repo_reverse_docker() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(names=["camptocamp/test:1.0"]),
                         },
@@ -1000,7 +1000,7 @@ def test_get_transversal_dashboard_repo_reverse_docker() -> None:
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -1019,14 +1019,14 @@ def test_get_transversal_dashboard_repo_reverse_docker() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[
                     _DependencyReverse(
                         name="camptocamp/other",
                         version="2.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -1045,7 +1045,7 @@ def test_get_transversal_dashboard_repo_reverse_docker_different() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=["camptocamp/test:prefix-1.0"],
@@ -1058,7 +1058,7 @@ def test_get_transversal_dashboard_repo_reverse_docker_different() -> None:
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -1077,14 +1077,14 @@ def test_get_transversal_dashboard_repo_reverse_docker_different() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[
                     _DependencyReverse(
                         name="camptocamp/other",
                         version="2.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -1103,7 +1103,7 @@ def test_get_transversal_dashboard_repo_reverse_docker_alternate_tag() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=["camptocamp/test:1.0", "camptocamp/test:latest"],
@@ -1116,7 +1116,7 @@ def test_get_transversal_dashboard_repo_reverse_docker_alternate_tag() -> None:
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={},
                     ),
                 },
@@ -1145,14 +1145,14 @@ def test_get_transversal_dashboard_repo_reverse_docker_alternate_tag() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[
                     _DependencyReverse(
                         name="camptocamp/other",
                         version="2.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -1171,7 +1171,7 @@ def test_get_transversal_dashboard_repo_reverse_unexisting() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={"pypi": _TransversalStatusNameByDatasource(names=["test"])},
                     ),
                 },
@@ -1180,7 +1180,7 @@ def test_get_transversal_dashboard_repo_reverse_unexisting() -> None:
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={"test": _TransversalStatusVersions(versions=["2.0.1"])},
@@ -1197,18 +1197,18 @@ def test_get_transversal_dashboard_repo_reverse_unexisting() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
             ),
             "2.0": _Dependencies(
-                support="Unsupported",
+                support={"type": "Unsupported"},
                 color="--bs-danger",
                 forward=[],
                 reverse=[
                     _DependencyReverse(
                         name="camptocamp/other",
                         version="2.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -1227,7 +1227,7 @@ def test_get_transversal_dashboard_repo_external() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={"other": _TransversalStatusVersions(versions=["2.0.1"])},
@@ -1241,7 +1241,14 @@ def test_get_transversal_dashboard_repo_external() -> None:
     context.params = {"repository": "camptocamp/test"}
     output = versions.get_transversal_dashboard(context)
     assert output.data["dependencies_branches"] == _DependenciesBranches(
-        by_branch={"1.0": _Dependencies(support="Best effort", color="--bs-body-bg", forward=[], reverse=[])},
+        by_branch={
+            "1.0": _Dependencies(
+                support={"type": "Best effort"},
+                color="--bs-body-bg",
+                forward=[],
+                reverse=[],
+            ),
+        },
     )
 
 
@@ -1262,7 +1269,7 @@ def test_get_transversal_dashboard_repo_reverse_other(datasource: str, package: 
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={"pypi": _TransversalStatusNameByDatasource(names=["test"])},
                     ),
                 },
@@ -1271,7 +1278,7 @@ def test_get_transversal_dashboard_repo_reverse_other(datasource: str, package: 
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             datasource: _TransversalStatusNameInDatasource(
                                 versions_by_names={package: _TransversalStatusVersions(versions=["1.0.1"])},
@@ -1285,7 +1292,14 @@ def test_get_transversal_dashboard_repo_reverse_other(datasource: str, package: 
     context.params = {"repository": "camptocamp/test"}
     output = versions.get_transversal_dashboard(context)
     assert output.data["dependencies_branches"] == _DependenciesBranches(
-        by_branch={"1.0": _Dependencies(support="Best effort", color="--bs-body-bg", forward=[], reverse=[])},
+        by_branch={
+            "1.0": _Dependencies(
+                support={"type": "Best effort"},
+                color="--bs-body-bg",
+                forward=[],
+                reverse=[],
+            ),
+        },
     )
 
 
@@ -1356,17 +1370,26 @@ async def test_update_upstream_versions() -> None:
         )
         assert transversal_status.repositories["endoflife.date/package1"].versions == {
             "1.0": _TransversalStatusVersion(
-                support="2038-12-31",
+                support={
+                    "type": "31/12/2038",
+                    "until": datetime.date(2038, 12, 31),
+                },
                 names_by_datasource={"datasource1": _TransversalStatusNameByDatasource(names=["package1"])},
             ),
         }
         assert transversal_status.repositories["endoflife.date/package2"].versions == {
             "v1.0": _TransversalStatusVersion(
-                support="2038-12-31",
+                support={
+                    "type": "31/12/2038",
+                    "until": datetime.date(2038, 12, 31),
+                },
                 names_by_datasource={"datasource2": _TransversalStatusNameByDatasource(names=["package2"])},
             ),
             "v2.0": _TransversalStatusVersion(
-                support="2039-12-31",
+                support={
+                    "type": "31/12/2039",
+                    "until": datetime.date(2039, 12, 31),
+                },
                 names_by_datasource={"datasource2": _TransversalStatusNameByDatasource(names=["package2"])},
             ),
         }
@@ -1752,7 +1775,7 @@ def test_build_reverse_dependency_uses_dependencies_index() -> None:
     target_repo = _TransversalStatusRepo(
         versions={
             "1.2": _TransversalStatusVersion(
-                support="Best effort",
+                support={"type": "Best effort"},
                 names_by_datasource={
                     "pypi": _TransversalStatusNameByDatasource(names=["pkg"]),
                 },
@@ -1763,7 +1786,7 @@ def test_build_reverse_dependency_uses_dependencies_index() -> None:
     dependent_repo = _TransversalStatusRepo(
         versions={
             "main": _TransversalStatusVersion(
-                support="Best effort",
+                support={"type": "Best effort"},
                 dependencies_by_datasource={},
             ),
         },
@@ -1802,7 +1825,7 @@ def test_build_reverse_dependency_uses_dependencies_index() -> None:
     assert dependencies_branches.by_branch["1.2"].reverse[0] == _DependencyReverse(
         name="org/dependent",
         version="main",
-        support="Best effort",
+        support={"type": "Best effort"},
         color="--bs-body-bg",
         repo="org/dependent",
     )
@@ -1812,7 +1835,7 @@ def test_build_reverse_dependency_uses_dependencies_index_docker() -> None:
     target_repo = _TransversalStatusRepo(
         versions={
             "1.2": _TransversalStatusVersion(
-                support="Best effort",
+                support={"type": "Best effort"},
                 names_by_datasource={
                     "docker": _TransversalStatusNameByDatasource(names=["image:latest"]),
                 },
@@ -1823,7 +1846,7 @@ def test_build_reverse_dependency_uses_dependencies_index_docker() -> None:
     dependent_repo = _TransversalStatusRepo(
         versions={
             "main": _TransversalStatusVersion(
-                support="Best effort",
+                support={"type": "Best effort"},
                 dependencies_by_datasource={},
             ),
         },
@@ -1862,7 +1885,7 @@ def test_build_reverse_dependency_uses_dependencies_index_docker() -> None:
     assert dependencies_branches.by_branch["1.2"].reverse[0] == _DependencyReverse(
         name="org/dependent",
         version="main",
-        support="Best effort",
+        support={"type": "Best effort"},
         color="--bs-body-bg",
         repo="org/dependent",
     )
@@ -1983,13 +2006,13 @@ def test_apply_additional_packages_least_support():
             "repo1": _TransversalStatusRepo(
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="2024-06-01",
+                        support={"type": "2024-06-01"},
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["dep1"]),
                         },
                     ),
                     "2.0": _TransversalStatusVersion(
-                        support="2023-06-01",
+                        support={"type": "2023-06-01"},
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["dep2"]),
                         },

--- a/tests/test_module_versions.py
+++ b/tests/test_module_versions.py
@@ -189,17 +189,35 @@ DEBUG: Determining if we should process repository camptocamp/tilecloud, using G
             },
             "has_security_policy": False,
             "names_index": {
-                "docker": {
-                    "ghcr.io/camptocamp/github-app-geo-project:master": {"master": "Best effort"},
-                },
-                "github-release": {
-                    "camptocamp/test": {"master": "Best effort"},
-                },
-                "npm": {
-                    "ghci": {"master": "Best effort"},
-                },
-                "pypi": {
-                    "github-app-geo-project": {"master": "Best effort"},
+                "by_datasource": {
+                    "docker": {
+                        "by_package": {
+                            "ghcr.io/camptocamp/github-app-geo-project:master": {
+                                "by_version": {"master": {"type": "Best effort"}},
+                            },
+                        },
+                    },
+                    "github-release": {
+                        "by_package": {
+                            "camptocamp/test": {
+                                "by_version": {"master": {"type": "Best effort"}},
+                            },
+                        },
+                    },
+                    "npm": {
+                        "by_package": {
+                            "ghci": {
+                                "by_version": {"master": {"type": "Best effort"}},
+                            },
+                        },
+                    },
+                    "pypi": {
+                        "by_package": {
+                            "github-app-geo-project": {
+                                "by_version": {"master": {"type": "Best effort"}},
+                            },
+                        },
+                    },
                 },
             },
             "versions": {
@@ -313,9 +331,15 @@ def test_get_transversal_dashboard_repo_forward(
             "camptocamp/other": _TransversalStatusRepo(
                 has_security_policy=True,
                 names_index={
-                    "pypi": {
-                        "other_package": {
-                            "2.0": other_support,
+                    "by_datasource": {
+                        "pypi": {
+                            "by_package": {
+                                "other_package": {
+                                    "by_version": {
+                                        "2.0": other_support,
+                                    },
+                                },
+                            },
                         },
                     },
                 },
@@ -376,9 +400,13 @@ def test_get_transversal_dashboard_repo_forward_docker() -> None:
             "camptocamp/other": _TransversalStatusRepo(
                 has_security_policy=True,
                 names_index={
-                    "docker": {
-                        "camptocamp/other:2.0": {
-                            "2.0": "Best effort",
+                    "by_datasource": {
+                        "docker": {
+                            "by_package": {
+                                "camptocamp/other:2.0": {
+                                    "by_version": {"2.0": {"type": "Best effort"}},
+                                },
+                            },
                         },
                     },
                 },
@@ -441,12 +469,16 @@ def test_get_transversal_dashboard_repo_forward_docker_2() -> None:
             "camptocamp/other": _TransversalStatusRepo(
                 has_security_policy=True,
                 names_index={
-                    "docker": {
-                        "osgeo/gdal:ubuntu-small-3.8.5": {
-                            "2.0": "Best effort",
-                        },
-                        "ghcr.io/osgeo/gdal:ubuntu-small-3.8.5": {
-                            "2.0": "Best effort",
+                    "by_datasource": {
+                        "docker": {
+                            "by_package": {
+                                "osgeo/gdal:ubuntu-small-3.8.5": {
+                                    "by_version": {"2.0": {"type": "Best effort"}},
+                                },
+                                "ghcr.io/osgeo/gdal:ubuntu-small-3.8.5": {
+                                    "by_version": {"2.0": {"type": "Best effort"}},
+                                },
+                            },
                         },
                     },
                 },
@@ -512,12 +544,16 @@ def test_get_transversal_dashboard_repo_forward_docker_double() -> None:
             "camptocamp/other": _TransversalStatusRepo(
                 has_security_policy=True,
                 names_index={
-                    "docker": {
-                        "camptocamp/other:1.0": {
-                            "1.0": "Best effort",
-                        },
-                        "camptocamp/other:2.0": {
-                            "2.0": "Best effort",
+                    "by_datasource": {
+                        "docker": {
+                            "by_package": {
+                                "camptocamp/other:1.0": {
+                                    "by_version": {"1.0": {"type": "Best effort"}},
+                                },
+                                "camptocamp/other:2.0": {
+                                    "by_version": {"2.0": {"type": "Best effort"}},
+                                },
+                            },
                         },
                     },
                 },
@@ -596,10 +632,16 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
             "camptocamp/other": _TransversalStatusRepo(
                 has_security_policy=True,
                 names_index={
-                    "docker": {
-                        "camptocamp/other:latest": {
-                            "1.0": "Best effort",
-                            "2.0": "Unsupported",
+                    "by_datasource": {
+                        "docker": {
+                            "by_package": {
+                                "camptocamp/other:latest": {
+                                    "by_version": {
+                                        "1.0": {"type": "Best effort"},
+                                        "2.0": {"type": "Unsupported"},
+                                    },
+                                },
+                            },
                         },
                     },
                 },
@@ -674,8 +716,14 @@ def test_get_transversal_dashboard_repo_forward_docker_empty_status() -> None:
             "camptocamp/other": _TransversalStatusRepo(
                 has_security_policy=True,
                 names_index={
-                    "docker": {
-                        "camptocamp/other:latest": {},
+                    "by_datasource": {
+                        "docker": {
+                            "by_package": {
+                                "camptocamp/other:latest": {
+                                    "by_version": {},
+                                },
+                            },
+                        },
                     },
                 },
             ),
@@ -727,9 +775,13 @@ def test_get_transversal_dashboard_repo_forward_inexisting() -> None:
             "camptocamp/other": _TransversalStatusRepo(
                 has_security_policy=True,
                 names_index={
-                    "pypi": {
-                        "other_package": {
-                            "3.0": "Best effort",
+                    "by_datasource": {
+                        "pypi": {
+                            "by_package": {
+                                "other_package": {
+                                    "by_version": {"3.0": {"type": "Best effort"}},
+                                },
+                            },
                         },
                     },
                 },
@@ -790,9 +842,13 @@ def test_get_transversal_dashboard_repo_forward_no_support() -> None:
             "camptocamp/other": _TransversalStatusRepo(
                 has_security_policy=False,
                 names_index={
-                    "pypi": {
-                        "other_package": {
-                            "master": "Best effort",
+                    "by_datasource": {
+                        "pypi": {
+                            "by_package": {
+                                "other_package": {
+                                    "by_version": {"master": {"type": "Best effort"}},
+                                },
+                            },
                         },
                     },
                 },
@@ -853,9 +909,15 @@ def test_get_transversal_dashboard_repo_forward_no_support_version() -> None:
             "camptocamp/other": _TransversalStatusRepo(
                 has_security_policy=True,
                 names_index={
-                    "pypi": {
-                        "other_package": {
-                            "1.0": {"type": "Date", "until": "2045-01-01"},
+                    "by_datasource": {
+                        "pypi": {
+                            "by_package": {
+                                "other_package": {
+                                    "by_version": {
+                                        "1.0": {"type": "Date", "until": "2045-01-01"},
+                                    },
+                                },
+                            },
                         },
                     },
                 },
@@ -1699,7 +1761,7 @@ def test_transversal_status_to_json():
             "package1": {
                 "dependencies_index": {"by_datasource": {}},
                 "has_security_policy": False,
-                "names_index": {},
+                "names_index": {"by_datasource": {}},
                 "url": "url1",
                 "versions": {},
             },
@@ -2102,10 +2164,16 @@ def test_apply_additional_packages_least_support():
     main_version = repo2.versions["main"]
     assert main_version.support.type.value == "Date"
     assert main_version.support.until == datetime.date(2023, 6, 1)
-    assert repo2.names_index.model_dump() == {
-        "pypi": {
-            "repo2": {
-                "main": "01/06/2023",
+    assert repo2.names_index.model_dump(mode="json") == {
+        "by_datasource": {
+            "pypi": {
+                "by_package": {
+                    "repo2": {
+                        "by_version": {
+                            "main": {"type": "Date", "until": "2023-06-01"},
+                        },
+                    },
+                },
             },
         },
     }

--- a/tests/test_module_versions.py
+++ b/tests/test_module_versions.py
@@ -157,7 +157,7 @@ DEBUG: Determining if we should process repository camptocamp/tilecloud, using G
                 "camptocamp/test": _TransversalStatusRepo(
                     versions={
                         "master": _TransversalStatusVersion(
-                            support={"type": "Best effort"},
+                            support="Best effort",
                         ),
                     },
                 ),
@@ -250,7 +250,7 @@ def test_get_transversal_dashboard() -> None:
             "camptocamp/test": _TransversalStatusRepo(
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -264,7 +264,7 @@ def test_get_transversal_dashboard() -> None:
             "camptocamp/other": _TransversalStatusRepo(
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["other_package"]),
                         },
@@ -294,7 +294,7 @@ def test_get_transversal_dashboard_repo_forward(other_support: str, expected_col
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Date", "until": datetime.date(2045, 1, 1)},
+                        support="1/1/2045",
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -330,7 +330,7 @@ def test_get_transversal_dashboard_repo_forward(other_support: str, expected_col
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Date", "until": datetime.date(2045, 1, 1)},
+                support="1/1/2045",
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
@@ -357,7 +357,7 @@ def test_get_transversal_dashboard_repo_forward_docker() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -379,7 +379,7 @@ def test_get_transversal_dashboard_repo_forward_docker() -> None:
                 },
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(names=["camptocamp/other:2.0"]),
                         },
@@ -393,14 +393,14 @@ def test_get_transversal_dashboard_repo_forward_docker() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Best effort"},
+                support="Best effort",
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="camptocamp/other",
                         datasource="docker",
                         version="2.0",
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -420,7 +420,7 @@ def test_get_transversal_dashboard_repo_forward_docker_2() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Date", "until": datetime.date(2027, 6, 27)},
+                        support="27/6/2027",
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -447,7 +447,7 @@ def test_get_transversal_dashboard_repo_forward_docker_2() -> None:
                 },
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=[
@@ -466,14 +466,14 @@ def test_get_transversal_dashboard_repo_forward_docker_2() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Date", "until": datetime.date(2027, 6, 27)},
+                support="27/6/2027",
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="ghcr.io/osgeo/gdal",
                         datasource="docker",
                         version="ubuntu-small-3.8.5",
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -493,7 +493,7 @@ def test_get_transversal_dashboard_repo_forward_docker_double() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -518,13 +518,13 @@ def test_get_transversal_dashboard_repo_forward_docker_double() -> None:
                 },
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(names=["camptocamp/other:1.0"]),
                         },
                     ),
                     "2.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(names=["camptocamp/other:2.0"]),
                         },
@@ -538,14 +538,14 @@ def test_get_transversal_dashboard_repo_forward_docker_double() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Best effort"},
+                support="Best effort",
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="camptocamp/other",
                         datasource="docker",
                         version="1.0",
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -553,7 +553,7 @@ def test_get_transversal_dashboard_repo_forward_docker_double() -> None:
                         name="camptocamp/other",
                         datasource="docker",
                         version="2.0",
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -577,7 +577,7 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Date", "until": datetime.date(2027, 6, 27)},
+                        support="27/6/2027",
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -600,7 +600,7 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
                 },
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=["camptocamp/other:latest"],
@@ -608,7 +608,7 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
                         },
                     ),
                     "2.0": _TransversalStatusVersion(
-                        support={"type": "Unsupported"},
+                        support="Unsupported",
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=["camptocamp/other:latest"],
@@ -624,14 +624,14 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Date", "until": datetime.date(2027, 6, 27)},
+                support="27/6/2027",
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="camptocamp/other",
                         datasource="docker",
                         version="latest",
-                        support={"type": "Unsupported"},
+                        support="Unsupported",
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -655,7 +655,7 @@ def test_get_transversal_dashboard_repo_forward_docker_empty_status() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Date", "until": datetime.date(2027, 6, 27)},
+                        support="27/6/2027",
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -681,14 +681,14 @@ def test_get_transversal_dashboard_repo_forward_docker_empty_status() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Date", "until": datetime.date(2027, 6, 27)},
+                support="27/6/2027",
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="camptocamp/other",
                         datasource="docker",
                         version="latest",
-                        support={"type": "No support defined"},
+                        support="No support defined",
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -708,7 +708,7 @@ def test_get_transversal_dashboard_repo_forward_inexisting() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -730,7 +730,7 @@ def test_get_transversal_dashboard_repo_forward_inexisting() -> None:
                 },
                 versions={
                     "3.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["other_package"]),
                         },
@@ -744,14 +744,14 @@ def test_get_transversal_dashboard_repo_forward_inexisting() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Best effort"},
+                support="Best effort",
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="other_package",
                         datasource="pypi",
                         version="2.0 (2.0.1)",
-                        support={"type": "Unsupported"},
+                        support="Unsupported",
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -771,7 +771,7 @@ def test_get_transversal_dashboard_repo_forward_no_support() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Date", "until": datetime.date(2045, 1, 1)},
+                        support="1/1/2045",
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -793,7 +793,7 @@ def test_get_transversal_dashboard_repo_forward_no_support() -> None:
                 },
                 versions={
                     "master": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["other_package"]),
                         },
@@ -807,14 +807,14 @@ def test_get_transversal_dashboard_repo_forward_no_support() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Date", "until": datetime.date(2045, 1, 1)},
+                support="1/1/2045",
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="other_package",
                         datasource="pypi",
                         version="2.0 (2.0.1)",
-                        support={"type": "No support defined"},
+                        support="No support defined",
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -834,7 +834,7 @@ def test_get_transversal_dashboard_repo_forward_no_support_version() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Date", "until": datetime.date(2045, 1, 1)},
+                        support="1/1/2045",
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -856,7 +856,7 @@ def test_get_transversal_dashboard_repo_forward_no_support_version() -> None:
                 },
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Date", "until": datetime.date(2045, 1, 1)},
+                        support="1/1/2045",
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["other_package"]),
                         },
@@ -870,14 +870,14 @@ def test_get_transversal_dashboard_repo_forward_no_support_version() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Date", "until": datetime.date(2045, 1, 1)},
+                support="1/1/2045",
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="other_package",
                         datasource="pypi",
                         version="2.0 (2.0.1)",
-                        support={"type": "Unsupported"},
+                        support="Unsupported",
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -897,7 +897,7 @@ def test_get_transversal_dashboard_repo_forward_no_package() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Date", "until": datetime.date(2045, 1, 1)},
+                        support="1/1/2045",
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -915,7 +915,7 @@ def test_get_transversal_dashboard_repo_forward_no_package() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Date", "until": datetime.date(2045, 1, 1)},
+                support="1/1/2045",
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[],
@@ -937,7 +937,7 @@ def test_get_transversal_dashboard_repo_reverse(other_support: str, expected_col
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Date", "until": datetime.date(2045, 1, 1)},
+                        support="1/1/2045",
                         names_by_datasource={"pypi": _TransversalStatusNameByDatasource(names=["test"])},
                     ),
                 },
@@ -963,7 +963,7 @@ def test_get_transversal_dashboard_repo_reverse(other_support: str, expected_col
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Date", "until": datetime.date(2045, 1, 1)},
+                support="1/1/2045",
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[
@@ -989,7 +989,7 @@ def test_get_transversal_dashboard_repo_reverse_docker() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(names=["camptocamp/test:1.0"]),
                         },
@@ -1000,7 +1000,7 @@ def test_get_transversal_dashboard_repo_reverse_docker() -> None:
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -1019,14 +1019,14 @@ def test_get_transversal_dashboard_repo_reverse_docker() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Best effort"},
+                support="Best effort",
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[
                     _DependencyReverse(
                         name="camptocamp/other",
                         version="2.0",
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -1045,7 +1045,7 @@ def test_get_transversal_dashboard_repo_reverse_docker_different() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=["camptocamp/test:prefix-1.0"],
@@ -1058,7 +1058,7 @@ def test_get_transversal_dashboard_repo_reverse_docker_different() -> None:
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -1077,14 +1077,14 @@ def test_get_transversal_dashboard_repo_reverse_docker_different() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Best effort"},
+                support="Best effort",
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[
                     _DependencyReverse(
                         name="camptocamp/other",
                         version="2.0",
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -1103,7 +1103,7 @@ def test_get_transversal_dashboard_repo_reverse_docker_alternate_tag() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=["camptocamp/test:1.0", "camptocamp/test:latest"],
@@ -1116,7 +1116,7 @@ def test_get_transversal_dashboard_repo_reverse_docker_alternate_tag() -> None:
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         dependencies_by_datasource={},
                     ),
                 },
@@ -1145,14 +1145,14 @@ def test_get_transversal_dashboard_repo_reverse_docker_alternate_tag() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Best effort"},
+                support="Best effort",
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[
                     _DependencyReverse(
                         name="camptocamp/other",
                         version="2.0",
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -1171,7 +1171,7 @@ def test_get_transversal_dashboard_repo_reverse_unexisting() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         names_by_datasource={"pypi": _TransversalStatusNameByDatasource(names=["test"])},
                     ),
                 },
@@ -1180,7 +1180,7 @@ def test_get_transversal_dashboard_repo_reverse_unexisting() -> None:
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={"test": _TransversalStatusVersions(versions=["2.0.1"])},
@@ -1197,18 +1197,18 @@ def test_get_transversal_dashboard_repo_reverse_unexisting() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Best effort"},
+                support="Best effort",
                 color="--bs-body-bg",
             ),
             "2.0": _Dependencies(
-                support={"type": "Unsupported"},
+                support="Unsupported",
                 color="--bs-danger",
                 forward=[],
                 reverse=[
                     _DependencyReverse(
                         name="camptocamp/other",
                         version="2.0",
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -1227,7 +1227,7 @@ def test_get_transversal_dashboard_repo_external() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={"other": _TransversalStatusVersions(versions=["2.0.1"])},
@@ -1243,7 +1243,7 @@ def test_get_transversal_dashboard_repo_external() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Best effort"},
+                support="Best effort",
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[],
@@ -1269,7 +1269,7 @@ def test_get_transversal_dashboard_repo_reverse_other(datasource: str, package: 
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         names_by_datasource={"pypi": _TransversalStatusNameByDatasource(names=["test"])},
                     ),
                 },
@@ -1278,7 +1278,7 @@ def test_get_transversal_dashboard_repo_reverse_other(datasource: str, package: 
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support={"type": "Best effort"},
+                        support="Best effort",
                         dependencies_by_datasource={
                             datasource: _TransversalStatusNameInDatasource(
                                 versions_by_names={package: _TransversalStatusVersions(versions=["1.0.1"])},
@@ -1294,7 +1294,7 @@ def test_get_transversal_dashboard_repo_reverse_other(datasource: str, package: 
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support={"type": "Best effort"},
+                support="Best effort",
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[],
@@ -1775,7 +1775,7 @@ def test_build_reverse_dependency_uses_dependencies_index() -> None:
     target_repo = _TransversalStatusRepo(
         versions={
             "1.2": _TransversalStatusVersion(
-                support={"type": "Best effort"},
+                support="Best effort",
                 names_by_datasource={
                     "pypi": _TransversalStatusNameByDatasource(names=["pkg"]),
                 },
@@ -1786,7 +1786,7 @@ def test_build_reverse_dependency_uses_dependencies_index() -> None:
     dependent_repo = _TransversalStatusRepo(
         versions={
             "main": _TransversalStatusVersion(
-                support={"type": "Best effort"},
+                support="Best effort",
                 dependencies_by_datasource={},
             ),
         },
@@ -1825,7 +1825,7 @@ def test_build_reverse_dependency_uses_dependencies_index() -> None:
     assert dependencies_branches.by_branch["1.2"].reverse[0] == _DependencyReverse(
         name="org/dependent",
         version="main",
-        support={"type": "Best effort"},
+        support="Best effort",
         color="--bs-body-bg",
         repo="org/dependent",
     )
@@ -1835,7 +1835,7 @@ def test_build_reverse_dependency_uses_dependencies_index_docker() -> None:
     target_repo = _TransversalStatusRepo(
         versions={
             "1.2": _TransversalStatusVersion(
-                support={"type": "Best effort"},
+                support="Best effort",
                 names_by_datasource={
                     "docker": _TransversalStatusNameByDatasource(names=["image:latest"]),
                 },
@@ -1846,7 +1846,7 @@ def test_build_reverse_dependency_uses_dependencies_index_docker() -> None:
     dependent_repo = _TransversalStatusRepo(
         versions={
             "main": _TransversalStatusVersion(
-                support={"type": "Best effort"},
+                support="Best effort",
                 dependencies_by_datasource={},
             ),
         },
@@ -1885,7 +1885,7 @@ def test_build_reverse_dependency_uses_dependencies_index_docker() -> None:
     assert dependencies_branches.by_branch["1.2"].reverse[0] == _DependencyReverse(
         name="org/dependent",
         version="main",
-        support={"type": "Best effort"},
+        support="Best effort",
         color="--bs-body-bg",
         repo="org/dependent",
     )
@@ -1989,8 +1989,8 @@ def test_support_cmp(a, b, expected):
 def test_apply_additional_packages_least_support():
     # Setup transversal_status with two dependencies, one with better support than the other
     from github_app_geo_project.module.versions import (
-        _UNSUPPORTED,
         _apply_additional_packages,
+        _SupportType,
         _TransversalStatus,
         _TransversalStatusNameByDatasource,
         _TransversalStatusRepo,
@@ -2006,13 +2006,13 @@ def test_apply_additional_packages_least_support():
             "repo1": _TransversalStatusRepo(
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support={"type": "2024-06-01"},
+                        support="2024-06-01",
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["dep1"]),
                         },
                     ),
                     "2.0": _TransversalStatusVersion(
-                        support={"type": "2023-06-01"},
+                        support="2023-06-01",
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["dep2"]),
                         },
@@ -2056,11 +2056,12 @@ def test_apply_additional_packages_least_support():
     # Should set support to the least support (most restrictive, i.e., "2023-06-01")
     repo2 = transversal_status.repositories["repo2"]
     main_version = repo2.versions["main"]
-    assert main_version.support == "2023-06-01"
+    assert main_version.support.type.value == "Date"
+    assert main_version.support.until == datetime.date(2023, 6, 1)
     assert repo2.names_index.model_dump() == {
         "pypi": {
             "repo2": {
-                "main": "2023-06-01",
+                "main": "01/06/2023",
             },
         },
     }
@@ -2086,4 +2087,4 @@ def test_apply_additional_packages_least_support():
     _apply_additional_packages(DummyContext(), transversal_status)
     repo3 = transversal_status.repositories["repo3"]
     main_version = repo3.versions["main"]
-    assert main_version.support == _UNSUPPORTED
+    assert main_version.support.type == _SupportType.UNSUPPORTED

--- a/tests/test_module_versions.py
+++ b/tests/test_module_versions.py
@@ -22,9 +22,9 @@ from github_app_geo_project.module.versions import (
     _parse_support_date,
     _read_dependencies,
     _rebuild_repo_dependencies,
+    _Support,
     _support_category,
     _support_cmp,
-    _support_from_value,
     _SupportCategory,
     _SupportType,
     _TransversalStatus,
@@ -159,7 +159,7 @@ DEBUG: Determining if we should process repository camptocamp/tilecloud, using G
                 "camptocamp/test": _TransversalStatusRepo(
                     versions={
                         "master": _TransversalStatusVersion(
-                            support="Best effort",
+                            support={"type": "Best effort"},
                         ),
                     },
                 ),
@@ -252,7 +252,7 @@ def test_get_transversal_dashboard() -> None:
             "camptocamp/test": _TransversalStatusRepo(
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -266,7 +266,7 @@ def test_get_transversal_dashboard() -> None:
             "camptocamp/other": _TransversalStatusRepo(
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["other_package"]),
                         },
@@ -283,11 +283,14 @@ def test_get_transversal_dashboard() -> None:
 @pytest.mark.parametrize(
     ("other_support", "expected_color"),
     [
-        ("01/01/2044", "--bs-danger"),
-        ("01/01/2046", "--bs-body-bg"),
+        ({"type": "Date", "until": "2044-01-01"}, "--bs-danger"),
+        ({"type": "Date", "until": "2046-01-01"}, "--bs-body-bg"),
     ],
 )
-def test_get_transversal_dashboard_repo_forward(other_support: str, expected_color: str) -> None:
+def test_get_transversal_dashboard_repo_forward(
+    other_support: dict[str, str],
+    expected_color: str,
+) -> None:
     versions = Versions()
     context = Mock()
     context.status = _TransversalStatus(
@@ -296,7 +299,7 @@ def test_get_transversal_dashboard_repo_forward(other_support: str, expected_col
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="1/1/2045",
+                        support={"type": "Date", "until": "2045-01-01"},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -332,7 +335,7 @@ def test_get_transversal_dashboard_repo_forward(other_support: str, expected_col
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="1/1/2045",
+                support={"type": "Date", "until": "2045-01-01"},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
@@ -359,7 +362,7 @@ def test_get_transversal_dashboard_repo_forward_docker() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -381,7 +384,7 @@ def test_get_transversal_dashboard_repo_forward_docker() -> None:
                 },
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(names=["camptocamp/other:2.0"]),
                         },
@@ -395,14 +398,14 @@ def test_get_transversal_dashboard_repo_forward_docker() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="camptocamp/other",
                         datasource="docker",
                         version="2.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -422,7 +425,7 @@ def test_get_transversal_dashboard_repo_forward_docker_2() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="27/6/2027",
+                        support={"type": "Date", "until": "2027-06-27"},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -449,7 +452,7 @@ def test_get_transversal_dashboard_repo_forward_docker_2() -> None:
                 },
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=[
@@ -468,14 +471,14 @@ def test_get_transversal_dashboard_repo_forward_docker_2() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="27/6/2027",
+                support={"type": "Date", "until": "2027-06-27"},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="ghcr.io/osgeo/gdal",
                         datasource="docker",
                         version="ubuntu-small-3.8.5",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -495,7 +498,7 @@ def test_get_transversal_dashboard_repo_forward_docker_double() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -520,13 +523,13 @@ def test_get_transversal_dashboard_repo_forward_docker_double() -> None:
                 },
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(names=["camptocamp/other:1.0"]),
                         },
                     ),
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(names=["camptocamp/other:2.0"]),
                         },
@@ -540,14 +543,14 @@ def test_get_transversal_dashboard_repo_forward_docker_double() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="camptocamp/other",
                         datasource="docker",
                         version="1.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -555,7 +558,7 @@ def test_get_transversal_dashboard_repo_forward_docker_double() -> None:
                         name="camptocamp/other",
                         datasource="docker",
                         version="2.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -579,7 +582,7 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="27/6/2027",
+                        support={"type": "Date", "until": "2027-06-27"},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -602,7 +605,7 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
                 },
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=["camptocamp/other:latest"],
@@ -610,7 +613,7 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
                         },
                     ),
                     "2.0": _TransversalStatusVersion(
-                        support="Unsupported",
+                        support={"type": "Unsupported"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=["camptocamp/other:latest"],
@@ -626,14 +629,14 @@ def test_get_transversal_dashboard_repo_forward_docker_multiple_statuses() -> No
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="27/6/2027",
+                support={"type": "Date", "until": "2027-06-27"},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="camptocamp/other",
                         datasource="docker",
                         version="latest",
-                        support="Unsupported",
+                        support={"type": "Unsupported"},
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -657,7 +660,7 @@ def test_get_transversal_dashboard_repo_forward_docker_empty_status() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="27/6/2027",
+                        support={"type": "Date", "until": "2027-06-27"},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -683,14 +686,14 @@ def test_get_transversal_dashboard_repo_forward_docker_empty_status() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="27/6/2027",
+                support={"type": "Date", "until": "2027-06-27"},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="camptocamp/other",
                         datasource="docker",
                         version="latest",
-                        support="No support defined",
+                        support={"type": "No support defined"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -710,7 +713,7 @@ def test_get_transversal_dashboard_repo_forward_inexisting() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -732,7 +735,7 @@ def test_get_transversal_dashboard_repo_forward_inexisting() -> None:
                 },
                 versions={
                     "3.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["other_package"]),
                         },
@@ -746,14 +749,14 @@ def test_get_transversal_dashboard_repo_forward_inexisting() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="other_package",
                         datasource="pypi",
                         version="2.0 (2.0.1)",
-                        support="Unsupported",
+                        support={"type": "Unsupported"},
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -773,7 +776,7 @@ def test_get_transversal_dashboard_repo_forward_no_support() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="1/1/2045",
+                        support={"type": "Date", "until": "2045-01-01"},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -795,7 +798,7 @@ def test_get_transversal_dashboard_repo_forward_no_support() -> None:
                 },
                 versions={
                     "master": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["other_package"]),
                         },
@@ -809,14 +812,14 @@ def test_get_transversal_dashboard_repo_forward_no_support() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="1/1/2045",
+                support={"type": "Date", "until": "2045-01-01"},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="other_package",
                         datasource="pypi",
                         version="2.0 (2.0.1)",
-                        support="No support defined",
+                        support={"type": "No support defined"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -836,7 +839,7 @@ def test_get_transversal_dashboard_repo_forward_no_support_version() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="1/1/2045",
+                        support={"type": "Date", "until": "2045-01-01"},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -852,13 +855,13 @@ def test_get_transversal_dashboard_repo_forward_no_support_version() -> None:
                 names_index={
                     "pypi": {
                         "other_package": {
-                            "1.0": "01/01/2045",
+                            "1.0": {"type": "Date", "until": "2045-01-01"},
                         },
                     },
                 },
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="1/1/2045",
+                        support={"type": "Date", "until": "2045-01-01"},
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["other_package"]),
                         },
@@ -872,14 +875,14 @@ def test_get_transversal_dashboard_repo_forward_no_support_version() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="1/1/2045",
+                support={"type": "Date", "until": "2045-01-01"},
                 color="--bs-body-bg",
                 forward=[
                     _Dependency(
                         name="other_package",
                         datasource="pypi",
                         version="2.0 (2.0.1)",
-                        support="Unsupported",
+                        support={"type": "Unsupported"},
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -899,7 +902,7 @@ def test_get_transversal_dashboard_repo_forward_no_package() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="1/1/2045",
+                        support={"type": "Date", "until": "2045-01-01"},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -917,7 +920,7 @@ def test_get_transversal_dashboard_repo_forward_no_package() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="1/1/2045",
+                support={"type": "Date", "until": "2045-01-01"},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[],
@@ -928,9 +931,15 @@ def test_get_transversal_dashboard_repo_forward_no_package() -> None:
 
 @pytest.mark.parametrize(
     ("other_support", "expected_color"),
-    [("01/01/2044", "--bs-body-bg"), ("01/01/2046", "--bs-danger")],
+    [
+        ({"type": "Date", "until": "2044-01-01"}, "--bs-body-bg"),
+        ({"type": "Date", "until": "2046-01-01"}, "--bs-danger"),
+    ],
 )
-def test_get_transversal_dashboard_repo_reverse(other_support: str, expected_color: str) -> None:
+def test_get_transversal_dashboard_repo_reverse(
+    other_support: dict[str, str],
+    expected_color: str,
+) -> None:
     versions = Versions()
     context = Mock()
     context.status = _TransversalStatus(
@@ -939,7 +948,7 @@ def test_get_transversal_dashboard_repo_reverse(other_support: str, expected_col
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="1/1/2045",
+                        support={"type": "Date", "until": "2045-01-01"},
                         names_by_datasource={"pypi": _TransversalStatusNameByDatasource(names=["test"])},
                     ),
                 },
@@ -965,7 +974,7 @@ def test_get_transversal_dashboard_repo_reverse(other_support: str, expected_col
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="1/1/2045",
+                support={"type": "Date", "until": "2045-01-01"},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[
@@ -991,7 +1000,7 @@ def test_get_transversal_dashboard_repo_reverse_docker() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(names=["camptocamp/test:1.0"]),
                         },
@@ -1002,7 +1011,7 @@ def test_get_transversal_dashboard_repo_reverse_docker() -> None:
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -1021,14 +1030,14 @@ def test_get_transversal_dashboard_repo_reverse_docker() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[
                     _DependencyReverse(
                         name="camptocamp/other",
                         version="2.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -1047,7 +1056,7 @@ def test_get_transversal_dashboard_repo_reverse_docker_different() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=["camptocamp/test:prefix-1.0"],
@@ -1060,7 +1069,7 @@ def test_get_transversal_dashboard_repo_reverse_docker_different() -> None:
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "docker": _TransversalStatusNameInDatasource(
                                 versions_by_names={
@@ -1079,14 +1088,14 @@ def test_get_transversal_dashboard_repo_reverse_docker_different() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[
                     _DependencyReverse(
                         name="camptocamp/other",
                         version="2.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -1105,7 +1114,7 @@ def test_get_transversal_dashboard_repo_reverse_docker_alternate_tag() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={
                             "docker": _TransversalStatusNameByDatasource(
                                 names=["camptocamp/test:1.0", "camptocamp/test:latest"],
@@ -1118,7 +1127,7 @@ def test_get_transversal_dashboard_repo_reverse_docker_alternate_tag() -> None:
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={},
                     ),
                 },
@@ -1147,14 +1156,14 @@ def test_get_transversal_dashboard_repo_reverse_docker_alternate_tag() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[
                     _DependencyReverse(
                         name="camptocamp/other",
                         version="2.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-body-bg",
                         repo="camptocamp/other",
                     ),
@@ -1173,7 +1182,7 @@ def test_get_transversal_dashboard_repo_reverse_unexisting() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={"pypi": _TransversalStatusNameByDatasource(names=["test"])},
                     ),
                 },
@@ -1182,7 +1191,7 @@ def test_get_transversal_dashboard_repo_reverse_unexisting() -> None:
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={"test": _TransversalStatusVersions(versions=["2.0.1"])},
@@ -1199,18 +1208,18 @@ def test_get_transversal_dashboard_repo_reverse_unexisting() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
             ),
             "2.0": _Dependencies(
-                support="Unsupported",
+                support={"type": "Unsupported"},
                 color="--bs-danger",
                 forward=[],
                 reverse=[
                     _DependencyReverse(
                         name="camptocamp/other",
                         version="2.0",
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         color="--bs-danger",
                         repo="camptocamp/other",
                     ),
@@ -1229,7 +1238,7 @@ def test_get_transversal_dashboard_repo_external() -> None:
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             "pypi": _TransversalStatusNameInDatasource(
                                 versions_by_names={"other": _TransversalStatusVersions(versions=["2.0.1"])},
@@ -1245,7 +1254,7 @@ def test_get_transversal_dashboard_repo_external() -> None:
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[],
@@ -1271,7 +1280,7 @@ def test_get_transversal_dashboard_repo_reverse_other(datasource: str, package: 
                 has_security_policy=True,
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         names_by_datasource={"pypi": _TransversalStatusNameByDatasource(names=["test"])},
                     ),
                 },
@@ -1280,7 +1289,7 @@ def test_get_transversal_dashboard_repo_reverse_other(datasource: str, package: 
                 has_security_policy=True,
                 versions={
                     "2.0": _TransversalStatusVersion(
-                        support="Best effort",
+                        support={"type": "Best effort"},
                         dependencies_by_datasource={
                             datasource: _TransversalStatusNameInDatasource(
                                 versions_by_names={package: _TransversalStatusVersions(versions=["1.0.1"])},
@@ -1296,7 +1305,7 @@ def test_get_transversal_dashboard_repo_reverse_other(datasource: str, package: 
     assert output.data["dependencies_branches"] == _DependenciesBranches(
         by_branch={
             "1.0": _Dependencies(
-                support="Best effort",
+                support={"type": "Best effort"},
                 color="--bs-body-bg",
                 forward=[],
                 reverse=[],
@@ -1346,7 +1355,10 @@ async def test_update_upstream_versions() -> None:
         )
         responses.get(
             "https://endoflife.date/api/package2.json",
-            payload=[{"eol": "2038-12-31", "cycle": "v1.0"}, {"eol": "2039-12-31", "cycle": "v2.0"}],
+            payload=[
+                {"eol": "2038-12-31", "cycle": "v1.0"},
+                {"eol": "2039-12-31", "cycle": "v2.0"},
+            ],
             status=200,
         )
 
@@ -1372,26 +1384,17 @@ async def test_update_upstream_versions() -> None:
         )
         assert transversal_status.repositories["endoflife.date/package1"].versions == {
             "1.0": _TransversalStatusVersion(
-                support={
-                    "type": "31/12/2038",
-                    "until": datetime.date(2038, 12, 31),
-                },
+                support={"type": "Date", "until": "2038-12-31"},
                 names_by_datasource={"datasource1": _TransversalStatusNameByDatasource(names=["package1"])},
             ),
         }
         assert transversal_status.repositories["endoflife.date/package2"].versions == {
             "v1.0": _TransversalStatusVersion(
-                support={
-                    "type": "31/12/2038",
-                    "until": datetime.date(2038, 12, 31),
-                },
+                support={"type": "Date", "until": "2038-12-31"},
                 names_by_datasource={"datasource2": _TransversalStatusNameByDatasource(names=["package2"])},
             ),
             "v2.0": _TransversalStatusVersion(
-                support={
-                    "type": "31/12/2039",
-                    "until": datetime.date(2039, 12, 31),
-                },
+                support={"type": "Date", "until": "2039-12-31"},
                 names_by_datasource={"datasource2": _TransversalStatusNameByDatasource(names=["package2"])},
             ),
         }
@@ -1777,7 +1780,7 @@ def test_build_reverse_dependency_uses_dependencies_index() -> None:
     target_repo = _TransversalStatusRepo(
         versions={
             "1.2": _TransversalStatusVersion(
-                support="Best effort",
+                support={"type": "Best effort"},
                 names_by_datasource={
                     "pypi": _TransversalStatusNameByDatasource(names=["pkg"]),
                 },
@@ -1788,7 +1791,7 @@ def test_build_reverse_dependency_uses_dependencies_index() -> None:
     dependent_repo = _TransversalStatusRepo(
         versions={
             "main": _TransversalStatusVersion(
-                support="Best effort",
+                support={"type": "Best effort"},
                 dependencies_by_datasource={},
             ),
         },
@@ -1827,7 +1830,7 @@ def test_build_reverse_dependency_uses_dependencies_index() -> None:
     assert dependencies_branches.by_branch["1.2"].reverse[0] == _DependencyReverse(
         name="org/dependent",
         version="main",
-        support="Best effort",
+        support={"type": "Best effort"},
         color="--bs-body-bg",
         repo="org/dependent",
     )
@@ -1837,7 +1840,7 @@ def test_build_reverse_dependency_uses_dependencies_index_docker() -> None:
     target_repo = _TransversalStatusRepo(
         versions={
             "1.2": _TransversalStatusVersion(
-                support="Best effort",
+                support={"type": "Best effort"},
                 names_by_datasource={
                     "docker": _TransversalStatusNameByDatasource(names=["image:latest"]),
                 },
@@ -1848,7 +1851,7 @@ def test_build_reverse_dependency_uses_dependencies_index_docker() -> None:
     dependent_repo = _TransversalStatusRepo(
         versions={
             "main": _TransversalStatusVersion(
-                support="Best effort",
+                support={"type": "Best effort"},
                 dependencies_by_datasource={},
             ),
         },
@@ -1887,7 +1890,7 @@ def test_build_reverse_dependency_uses_dependencies_index_docker() -> None:
     assert dependencies_branches.by_branch["1.2"].reverse[0] == _DependencyReverse(
         name="org/dependent",
         version="main",
-        support="Best effort",
+        support={"type": "Best effort"},
         color="--bs-body-bg",
         repo="org/dependent",
     )
@@ -1910,19 +1913,18 @@ def test_build_reverse_dependency_uses_dependencies_index_docker() -> None:
         ("2040-01-01", "To be defined", False),
         ("2040-01-01", "Unsupported", False),
         ("2040-01-01", "Best effort", False),
-        ("01/01/2040", "2040-01-01", True),
-        ("2040-01-01", "01/01/2040", True),
-        ("01/01/2045", "01/01/2046", True),
-        ("01/01/2045", "01/01/2044", False),
-        ("01/01/2046", "01/01/2045", False),
-        ("01/01/2044", "01/01/2045", True),
+        ("2040-01-01", "2040-01-01", True),
+        ("2045-01-01", "2046-01-01", True),
+        ("2045-01-01", "2044-01-01", False),
+        ("2046-01-01", "2045-01-01", False),
+        ("2044-01-01", "2045-01-01", True),
     ],
 )
 def test_is_supported(support, dependency_support, expected_result):
     assert (
         _is_supported(
-            _support_from_value(support),
-            _support_from_value(dependency_support),
+            _Support.model_validate(support),
+            _Support.model_validate(dependency_support),
         )
         == expected_result
     )
@@ -1931,8 +1933,8 @@ def test_is_supported(support, dependency_support, expected_result):
 @pytest.mark.parametrize(
     ("text", "expected_year", "expected_month", "expected_day", "expected_none"),
     [
-        ("2024-06-01", 2024, 6, 1, False),
         ("01/06/2024", 2024, 6, 1, False),
+        ("2024-06-01", 2024, 6, 1, False),
         ("notadate", None, None, None, True),
     ],
 )
@@ -1991,21 +1993,21 @@ def test_support_category(value, expected):
     ],
 )
 def test_support_cmp(a, b, expected):
-    assert _support_cmp(_support_from_value(a), _support_from_value(b)) == expected
+    assert _support_cmp(_Support.model_validate(a), _Support.model_validate(b)) == expected
 
 
 def test_support_cmp_enum() -> None:
     assert (
         _support_cmp(
-            _support_from_value(_SupportType.BEST_EFFORT),
-            _support_from_value(_SupportType.UNSUPPORTED),
+            _Support(type=_SupportType.BEST_EFFORT),
+            _Support(type=_SupportType.UNSUPPORTED),
         )
         == 1
     )
     assert (
         _support_cmp(
-            _support_from_value(_SupportType.UNSUPPORTED),
-            _support_from_value(_SupportType.BEST_EFFORT),
+            _Support(type=_SupportType.UNSUPPORTED),
+            _Support(type=_SupportType.BEST_EFFORT),
         )
         == -1
     )
@@ -2014,15 +2016,15 @@ def test_support_cmp_enum() -> None:
 def test_is_supported_enum() -> None:
     assert (
         _is_supported(
-            _support_from_value(_SupportType.BEST_EFFORT),
-            _support_from_value(_SupportType.UNSUPPORTED),
+            _Support(type=_SupportType.BEST_EFFORT),
+            _Support(type=_SupportType.UNSUPPORTED),
         )
         is False
     )
     assert (
         _is_supported(
-            _support_from_value(_SupportType.UNSUPPORTED),
-            _support_from_value(_SupportType.BEST_EFFORT),
+            _Support(type=_SupportType.UNSUPPORTED),
+            _Support(type=_SupportType.BEST_EFFORT),
         )
         is True
     )
@@ -2048,13 +2050,13 @@ def test_apply_additional_packages_least_support():
             "repo1": _TransversalStatusRepo(
                 versions={
                     "1.0": _TransversalStatusVersion(
-                        support="2024-06-01",
+                        support={"type": "Date", "until": "2024-06-01"},
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["dep1"]),
                         },
                     ),
                     "2.0": _TransversalStatusVersion(
-                        support="2023-06-01",
+                        support={"type": "Date", "until": "2023-06-01"},
                         names_by_datasource={
                             "pypi": _TransversalStatusNameByDatasource(names=["dep2"]),
                         },
@@ -2095,7 +2097,7 @@ def test_apply_additional_packages_least_support():
     # Apply
     _apply_additional_packages(DummyContext(), transversal_status)
 
-    # Should set support to the least support (most restrictive, i.e., "2023-06-01")
+    # Should set support to the least support (most restrictive, i.e., {"type": "Date", "until": "2023-06-01"})
     repo2 = transversal_status.repositories["repo2"]
     main_version = repo2.versions["main"]
     assert main_version.support.type.value == "Date"

--- a/tests/test_module_versions.py
+++ b/tests/test_module_versions.py
@@ -22,6 +22,7 @@ from github_app_geo_project.module.versions import (
     _parse_support_date,
     _read_dependencies,
     _rebuild_repo_dependencies,
+    _Support,
     _support_category,
     _support_cmp,
     _SupportCategory,
@@ -1993,8 +1994,20 @@ def test_support_cmp_enum() -> None:
 
 
 def test_is_supported_enum() -> None:
-    assert _is_supported(_SupportType.BEST_EFFORT, _SupportType.UNSUPPORTED) is False
-    assert _is_supported(_SupportType.UNSUPPORTED, _SupportType.BEST_EFFORT) is True
+    assert (
+        _is_supported(
+            _Support(type=_SupportType.BEST_EFFORT),
+            _Support(type=_SupportType.UNSUPPORTED),
+        )
+        is False
+    )
+    assert (
+        _is_supported(
+            _Support(type=_SupportType.UNSUPPORTED),
+            _Support(type=_SupportType.BEST_EFFORT),
+        )
+        is True
+    )
 
 
 def test_apply_additional_packages_least_support():


### PR DESCRIPTION
## Summary
- Format `endoflife.date` support dates as `jj/mm/aaaa` when ingesting cycles
- Keep only future `eol` dates to align with existing support logic