### PR TITLE
Audit: Close stale pull request issues on pull request close

### DIFF
--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -584,6 +584,20 @@ class Audit(
         Usually the only action allowed to be done in this method is to set the pull request checks status
         Note that this function is called in the web server Pod who has low resources, and this call should be fast
         """
+        if context.module_event_name == "pull_request":
+            event_data_pull_request = githubkit.webhooks.parse_obj(
+                "pull_request",
+                context.github_event_data,
+            )
+            if event_data_pull_request.action == "closed":
+                return [
+                    module.Action(
+                        priority=module.PRIORITY_STANDARD,
+                        data=_EventData(type="close-pull-request-issues"),
+                        title="close-pull-request-issues",
+                    )
+                ]
+
         if context.module_event_name == "push":
             event_data_push = githubkit.webhooks.parse_obj(
                 "push",
@@ -684,6 +698,17 @@ class Audit(
         short_message: list[str] = []
         success = True
         intermediate_status = _IntermediateStatus(status=_TransversalStatusRepo())
+
+        if context.module_event_data.type == "close-pull-request-issues":
+            event_data_pull_request = githubkit.webhooks.parse_obj(
+                "pull_request",
+                context.github_event_data,
+            )
+            await module_utils.close_pull_request_related_issues(
+                context.github_project,
+                event_data_pull_request.pull_request.number,
+            )
+            return module.ProcessOutput(success=True)
 
         # Handle cleanup when SECURITY.md is removed on default branch
         if context.module_event_data.type == "cleanup":
@@ -994,7 +1019,7 @@ class Audit(
                 "contents": "write",
                 "workflows": "write",
             },
-            {"push"},
+            {"push", "pull_request"},
         )
 
     def has_transversal_dashboard(self) -> bool:

--- a/github_app_geo_project/module/utils.py
+++ b/github_app_geo_project/module/utils.py
@@ -934,7 +934,7 @@ async def close_pull_request_issues(
             ref=new_branch,
         )
 
-    title = f"Pull request {message} is open for 5 days"
+    title_start = f"Pull request {message} is open for "
     issues = (
         await github_project.aio_github.rest.issues.async_list_for_repo(
             owner=github_project.owner,
@@ -945,7 +945,32 @@ async def close_pull_request_issues(
     ).parsed_data
     assert issues is not None
     for issue in issues:
-        if title == issue.title:
+        if issue.title.startswith(title_start):
+            await github_project.aio_github.rest.issues.async_update(
+                owner=github_project.owner,
+                repo=github_project.repository,
+                issue_number=issue.number,
+                state="closed",
+            )
+
+
+async def close_pull_request_related_issues(
+    github_project: configuration.GithubProject,
+    pull_request_number: int,
+) -> None:
+    """Close all warning issues related to a pull request number."""
+    issue_body = f"See: #{pull_request_number}"
+    issues = (
+        await github_project.aio_github.rest.issues.async_list_for_repo(
+            owner=github_project.owner,
+            repo=github_project.repository,
+            state="open",
+            creator=f"{github_project.application.slug}[bot]",
+        )
+    ).parsed_data
+    assert issues is not None
+    for issue in issues:
+        if issue.title.startswith("Pull request ") and issue.body == issue_body:
             await github_project.aio_github.rest.issues.async_update(
                 owner=github_project.owner,
                 repo=github_project.repository,

--- a/tests/test_module_audit.py
+++ b/tests/test_module_audit.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
-from github_app_geo_project.module.audit import _EventData, _process_renovate
+from github_app_geo_project.module.audit import Audit, _EventData, _process_renovate
 
 
 @pytest.mark.asyncio
@@ -295,3 +295,45 @@ async def test_process_renovate_version_cleanup_pr_creation_failure():
 
                 # Assertions
                 assert result is False
+
+
+def test_get_actions_pull_request_closed() -> None:
+    """Test that a closed pull request triggers issue closing action."""
+    context = Mock()
+    context.module_event_name = "pull_request"
+    context.github_event_data = {"action": "closed"}
+
+    event_data = Mock()
+    event_data.action = "closed"
+
+    with patch("githubkit.webhooks.parse_obj", return_value=event_data):
+        actions = Audit().get_actions(context)
+
+    assert len(actions) == 1
+    assert actions[0].data == _EventData(type="close-pull-request-issues")
+
+
+@pytest.mark.asyncio
+async def test_process_close_pull_request_issues_action() -> None:
+    """Test processing close-pull-request-issues event data."""
+    context = Mock()
+    context.module_event_data = _EventData(type="close-pull-request-issues")
+    context.github_event_data = {"action": "closed"}
+    context.github_project = Mock()
+    context.issue_data = ""
+
+    event_data = Mock()
+    event_data.pull_request = Mock()
+    event_data.pull_request.number = 42
+
+    with (
+        patch("githubkit.webhooks.parse_obj", return_value=event_data),
+        patch(
+            "github_app_geo_project.module.audit.module_utils.close_pull_request_related_issues",
+            new=AsyncMock(),
+        ) as mock_close_related,
+    ):
+        result = await Audit().process(context)
+
+    mock_close_related.assert_awaited_once_with(context.github_project, 42)
+    assert result.success is True

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -1,5 +1,7 @@
 import datetime
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
 
 from github_app_geo_project.module import utils
 
@@ -186,3 +188,72 @@ def test_manage_updated_separated():
 
     assert "key3" not in updated
     assert "key3" not in data
+
+
+@pytest.mark.asyncio
+async def test_close_pull_request_issues_close_matching_issue() -> None:
+    github_project = MagicMock()
+    github_project.owner = "owner"
+    github_project.repository = "repo"
+    github_project.application.slug = "my-app"
+
+    github_project.aio_github.rest.pulls.async_list = AsyncMock(return_value=MagicMock(parsed_data=[]))
+    github_project.aio_github.rest.git.async_delete_ref = AsyncMock()
+
+    issue_to_close = MagicMock()
+    issue_to_close.title = "Pull request Audit Snyk check/fix 1.2 is open for 14 days"
+    issue_to_close.number = 101
+    issue_other = MagicMock()
+    issue_other.title = "Unrelated issue"
+    issue_other.number = 202
+
+    github_project.aio_github.rest.issues.async_list_for_repo = AsyncMock(
+        return_value=MagicMock(parsed_data=[issue_to_close, issue_other]),
+    )
+    github_project.aio_github.rest.issues.async_update = AsyncMock()
+
+    await utils.close_pull_request_issues("ghci/audit/snyk/1.2", "Audit Snyk check/fix 1.2", github_project)
+
+    github_project.aio_github.rest.issues.async_update.assert_awaited_once_with(
+        owner="owner",
+        repo="repo",
+        issue_number=101,
+        state="closed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_close_pull_request_related_issues_close_by_pull_request_number() -> None:
+    github_project = MagicMock()
+    github_project.owner = "owner"
+    github_project.repository = "repo"
+    github_project.application.slug = "my-app"
+
+    issue_to_close = MagicMock()
+    issue_to_close.title = "Pull request Audit Dpkg 2.0 is open for 9 days"
+    issue_to_close.body = "See: #42"
+    issue_to_close.number = 303
+
+    issue_wrong_pr = MagicMock()
+    issue_wrong_pr.title = "Pull request Audit Dpkg 2.0 is open for 9 days"
+    issue_wrong_pr.body = "See: #43"
+    issue_wrong_pr.number = 404
+
+    issue_wrong_title = MagicMock()
+    issue_wrong_title.title = "Audit warning"
+    issue_wrong_title.body = "See: #42"
+    issue_wrong_title.number = 505
+
+    github_project.aio_github.rest.issues.async_list_for_repo = AsyncMock(
+        return_value=MagicMock(parsed_data=[issue_to_close, issue_wrong_pr, issue_wrong_title]),
+    )
+    github_project.aio_github.rest.issues.async_update = AsyncMock()
+
+    await utils.close_pull_request_related_issues(github_project, 42)
+
+    github_project.aio_github.rest.issues.async_update.assert_awaited_once_with(
+        owner="owner",
+        repo="repo",
+        issue_number=303,
+        state="closed",
+    )


### PR DESCRIPTION
## Summary
- Fix `audit` stale-issue cleanup by matching issue titles with a stable prefix instead of an exact `5 days` title, so older reminder `issues` are correctly closed.
- Trigger `audit` on `pull_request` `closed` events and close reminder `issues` linked to the closed `pull request` using `See: #<number>` matching.
- Add focused tests for `audit.get_actions`, `audit.process`, and `module.utils` issue-closing helpers.