### PR TITLE
Project: Restore logs link in repository view

### DIFF
--- a/github_app_geo_project/templates/project.html
+++ b/github_app_geo_project/templates/project.html
@@ -208,10 +208,10 @@
           <!---->
           %endif
           <!---->
-          %if job.log:
-          <a href="${request.route_url('logs', id=job.id)}">Logs</a>
-          %elif job.status_enum.value in ['new', 'pending']:
+          %if job.status_enum.value in ['new', 'pending']:
           <a href="${request.route_url('logs', id=job.id)}">Status</a>
+          %else:
+          <a href="${request.route_url('logs', id=job.id)}">Logs</a>
           %endif
         </div>
         <!-- for Prettier -->


### PR DESCRIPTION
## Summary
- Restore the `Logs` link in the repository `project` view after logs moved to `JobLogEntry`.
- Stop relying on legacy `job.log` presence to display navigation to `/logs/<job_id>`.
- Keep `Status` label for `new`/`pending` jobs and `Logs` for other statuses.
