### PR TITLE
Audit: Fix pull request issue closing with pagination and robust PR reference matching

### DIFF
--- a/github_app_geo_project/module/utils.py
+++ b/github_app_geo_project/module/utils.py
@@ -941,16 +941,14 @@ async def close_pull_request_issues(
         )
 
     title_start = f"Pull request {message} is open for "
-    issues = (
-        await github_project.aio_github.rest.issues.async_list_for_repo(
-            owner=github_project.owner,
-            repo=github_project.repository,
-            state="open",
-            creator=f"{github_project.application.slug}[bot]",
-        )
-    ).parsed_data
-    assert issues is not None
-    for issue in issues:
+    issue: githubkit.versions.latest.models.Issue
+    async for issue in github_project.aio_github.paginate(
+        github_project.aio_github.rest.issues.async_list_for_repo,
+        owner=github_project.owner,
+        repo=github_project.repository,
+        state="open",
+        creator=f"{github_project.application.slug}[bot]",
+    ):
         if issue.title.startswith(title_start):
             await github_project.aio_github.rest.issues.async_update(
                 owner=github_project.owner,
@@ -965,18 +963,17 @@ async def close_pull_request_related_issues(
     pull_request_number: int,
 ) -> None:
     """Close all warning issues related to a pull request number."""
-    issue_body = f"See: #{pull_request_number}"
-    issues = (
-        await github_project.aio_github.rest.issues.async_list_for_repo(
-            owner=github_project.owner,
-            repo=github_project.repository,
-            state="open",
-            creator=f"{github_project.application.slug}[bot]",
-        )
-    ).parsed_data
-    assert issues is not None
-    for issue in issues:
-        if issue.title.startswith("Pull request ") and issue.body == issue_body:
+    issue: githubkit.versions.latest.models.Issue
+    async for issue in github_project.aio_github.paginate(
+        github_project.aio_github.rest.issues.async_list_for_repo,
+        owner=github_project.owner,
+        repo=github_project.repository,
+        state="open",
+        creator=f"{github_project.application.slug}[bot]",
+    ):
+        body: str = issue.body or ""
+        references = {int(match.group(1)) for match in re.finditer(r"(?m)^See:\s*#(\d+)\s*$", body)}
+        if issue.title.startswith("Pull request ") and pull_request_number in references:
             await github_project.aio_github.rest.issues.async_update(
                 owner=github_project.owner,
                 repo=github_project.repository,

--- a/github_app_geo_project/module/utils.py
+++ b/github_app_geo_project/module/utils.py
@@ -71,6 +71,8 @@ DashboardIssueRaw = list[DashboardIssueItem | str]
 
 _CHECK_RE = re.compile(r"- \[([ x])\] (.*)")
 _COMMENT_RE = re.compile(r"^(.*)<!--(.*)-->(.*)$")
+_PULL_REQUEST_ISSUE_TITLE_PREFIX = "Pull request "
+_PULL_REQUEST_REFERENCE_RE = re.compile(r"(?m)^See:\s*#(\d+)\s*$")
 
 
 def parse_dashboard_issue(issue_data: str) -> DashboardIssueRaw:
@@ -971,9 +973,12 @@ async def close_pull_request_related_issues(
         state="open",
         creator=f"{github_project.application.slug}[bot]",
     ):
+        if not issue.title.startswith(_PULL_REQUEST_ISSUE_TITLE_PREFIX):
+            continue
+
         body: str = issue.body or ""
-        references = {int(match.group(1)) for match in re.finditer(r"(?m)^See:\s*#(\d+)\s*$", body)}
-        if issue.title.startswith("Pull request ") and pull_request_number in references:
+        references = {int(match.group(1)) for match in _PULL_REQUEST_REFERENCE_RE.finditer(body)}
+        if pull_request_number in references:
             await github_project.aio_github.rest.issues.async_update(
                 owner=github_project.owner,
                 repo=github_project.repository,

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -6,6 +6,11 @@ import pytest
 from github_app_geo_project.module import utils
 
 
+async def _aiter(items):
+    for item in items:
+        yield item
+
+
 def test_parse_dashboard_issue() -> None:
     issue_data = "first\n- [x] <!-- comment --> title\n- [ ] title2\n\nother"
     result = utils.parse_dashboard_issue(issue_data)
@@ -207,9 +212,7 @@ async def test_close_pull_request_issues_close_matching_issue() -> None:
     issue_other.title = "Unrelated issue"
     issue_other.number = 202
 
-    github_project.aio_github.rest.issues.async_list_for_repo = AsyncMock(
-        return_value=MagicMock(parsed_data=[issue_to_close, issue_other]),
-    )
+    github_project.aio_github.paginate = MagicMock(return_value=_aiter([issue_to_close, issue_other]))
     github_project.aio_github.rest.issues.async_update = AsyncMock()
 
     await utils.close_pull_request_issues("ghci/audit/snyk/1.2", "Audit Snyk check/fix 1.2", github_project)
@@ -231,7 +234,7 @@ async def test_close_pull_request_related_issues_close_by_pull_request_number() 
 
     issue_to_close = MagicMock()
     issue_to_close.title = "Pull request Audit Dpkg 2.0 is open for 9 days"
-    issue_to_close.body = "See: #42"
+    issue_to_close.body = "See: #42\n\n[Logs](https://example.com/logs/123)"
     issue_to_close.number = 303
 
     issue_wrong_pr = MagicMock()
@@ -244,8 +247,8 @@ async def test_close_pull_request_related_issues_close_by_pull_request_number() 
     issue_wrong_title.body = "See: #42"
     issue_wrong_title.number = 505
 
-    github_project.aio_github.rest.issues.async_list_for_repo = AsyncMock(
-        return_value=MagicMock(parsed_data=[issue_to_close, issue_wrong_pr, issue_wrong_title]),
+    github_project.aio_github.paginate = MagicMock(
+        return_value=_aiter([issue_to_close, issue_wrong_pr, issue_wrong_title]),
     )
     github_project.aio_github.rest.issues.async_update = AsyncMock()
 


### PR DESCRIPTION
## Summary
- Fix `audit` issue cleanup on PR close by scanning all pages of bot-created open issues with `aio_github.paginate`.
- Make related-issue matching robust by detecting `See: #<PR>` references in issue bodies even when additional lines/links are present.
- Keep scope constrained to open issues for efficiency and add tests covering multiline body matching with pagination-based iteration.