### PR TITLE
Clean: Delete bot-only branches on closed unmerged pull requests

### DIFF
--- a/github_app_geo_project/module/clean/__init__.py
+++ b/github_app_geo_project/module/clean/__init__.py
@@ -113,6 +113,9 @@ class Clean(module.Module[configuration.CleanConfiguration, _ActionData, None, N
         context: module.ProcessContext[configuration.CleanConfiguration, _ActionData],
     ) -> module.ProcessOutput[_ActionData, None]:
         """Process the action."""
+        if context.module_event_data.type == "pull_request":
+            await self._delete_closed_pull_request_branch_if_bot_only(context)
+
         if context.module_config.get("docker", True):
             await self._clean_docker(context)
         for git in context.module_config.get("git", []):
@@ -120,6 +123,100 @@ class Clean(module.Module[configuration.CleanConfiguration, _ActionData, None, N
                 await self._clean_git(context, git)
 
         return module.ProcessOutput()
+
+    @staticmethod
+    def _is_bot_login(login: str | None) -> bool:
+        """Return True when the login is clearly a bot login."""
+        return bool(login and login.endswith("[bot]"))
+
+    @classmethod
+    def _looks_like_bot_identity(cls, name: str | None, email: str | None) -> bool:
+        """Return True when the name or email looks like a bot identity."""
+        if name and "[bot]" in name:
+            return True
+
+        if not email:
+            return False
+
+        if "[bot]" in email:
+            return True
+
+        email_lower = email.lower()
+        if email_lower.endswith("@users.noreply.github.com"):
+            local_part = email_lower.split("@", 1)[0]
+            return local_part.endswith("[bot]")
+
+        return False
+
+    @classmethod
+    def _is_bot_commit(cls, commit: Any) -> bool:
+        """Return True when a commit appears to be authored/committed by a bot."""
+        if cls._is_bot_login(commit.author.login if commit.author else None):
+            return True
+        if cls._is_bot_login(commit.committer.login if commit.committer else None):
+            return True
+
+        author = commit.commit.author if commit.commit else None
+        if cls._looks_like_bot_identity(
+            author.name if author else None,
+            author.email if author else None,
+        ):
+            return True
+
+        committer = commit.commit.committer if commit.commit else None
+        return cls._looks_like_bot_identity(
+            committer.name if committer else None,
+            committer.email if committer else None,
+        )
+
+    async def _delete_closed_pull_request_branch_if_bot_only(
+        self,
+        context: module.ProcessContext[configuration.CleanConfiguration, _ActionData],
+    ) -> None:
+        """Delete the source branch when a closed non-merged pull request has bot-only commits."""
+        event_data_pull_request = githubkit.webhooks.parse_obj(
+            "pull_request",
+            context.github_event_data,
+        )
+        if event_data_pull_request.action != "closed":
+            return
+        if event_data_pull_request.pull_request.merged:
+            return
+
+        head_repo = event_data_pull_request.pull_request.head.repo
+        base_repo = event_data_pull_request.pull_request.base.repo
+        if not head_repo or not base_repo or head_repo.id != base_repo.id:
+            return
+
+        branch_name = event_data_pull_request.pull_request.head.ref
+        default_branch = context.github_event_data.get("repository", {}).get("default_branch")
+        if branch_name == default_branch:
+            return
+
+        has_commits = False
+        commit: Any
+        async for commit in context.github_project.aio_github.paginate(
+            context.github_project.aio_github.rest.pulls.async_list_commits,
+            owner=context.github_project.owner,
+            repo=context.github_project.repository,
+            pull_number=event_data_pull_request.pull_request.number,
+        ):
+            has_commits = True
+            if not self._is_bot_commit(commit):
+                return
+
+        if not has_commits:
+            return
+
+        try:
+            await context.github_project.aio_github.rest.git.async_delete_ref(
+                owner=context.github_project.owner,
+                repo=context.github_project.repository,
+                ref=f"heads/{branch_name}",
+            )
+        except githubkit.exception.RequestFailed as exception:
+            if exception.response.status_code not in (404, 422):
+                raise
 
     async def _clean_docker(
         self,

--- a/tests/test_module_clean.py
+++ b/tests/test_module_clean.py
@@ -1,0 +1,108 @@
+"""Tests for the clean module."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from github_app_geo_project.module.clean import Clean
+
+
+async def _aiter(values):
+    for value in values:
+        yield value
+
+
+def _make_pull_request_event(*, merged: bool, head_ref: str = "ghci/test-bot"):
+    event_data = MagicMock()
+    event_data.action = "closed"
+    event_data.pull_request = MagicMock()
+    event_data.pull_request.merged = merged
+    event_data.pull_request.number = 42
+    event_data.pull_request.head = MagicMock()
+    event_data.pull_request.head.ref = head_ref
+    event_data.pull_request.head.repo = MagicMock(id=1)
+    event_data.pull_request.base = MagicMock()
+    event_data.pull_request.base.repo = MagicMock(id=1)
+    return event_data
+
+
+def _make_bot_commit():
+    commit = MagicMock()
+    commit.author = MagicMock(login="renovate[bot]")
+    commit.committer = MagicMock(login="renovate[bot]")
+    commit.commit = MagicMock()
+    commit.commit.author = MagicMock(
+        name="renovate[bot]", email="29139614+renovate[bot]@users.noreply.github.com"
+    )
+    commit.commit.committer = MagicMock(
+        name="renovate[bot]", email="29139614+renovate[bot]@users.noreply.github.com"
+    )
+    return commit
+
+
+def _make_human_commit():
+    commit = MagicMock()
+    commit.author = MagicMock(login="alice")
+    commit.committer = MagicMock(login="alice")
+    commit.commit = MagicMock()
+    commit.commit.author = MagicMock(name="Alice", email="alice@example.com")
+    commit.commit.committer = MagicMock(name="Alice", email="alice@example.com")
+    return commit
+
+
+def _make_context(commits):
+    context = MagicMock()
+    context.module_event_data.type = "pull_request"
+    context.module_config = {"docker": False, "git": []}
+    context.github_event_data = {"repository": {"default_branch": "main"}}
+    context.github_project.owner = "owner"
+    context.github_project.repository = "repo"
+    context.github_project.aio_github.paginate = MagicMock(return_value=_aiter(commits))
+    context.github_project.aio_github.rest.git.async_delete_ref = AsyncMock()
+    return context
+
+
+@pytest.mark.asyncio
+async def test_process_delete_branch_on_closed_non_merged_bot_only_pull_request() -> None:
+    clean_module = Clean()
+    context = _make_context([_make_bot_commit()])
+
+    with patch(
+        "githubkit.webhooks.parse_obj",
+        return_value=_make_pull_request_event(merged=False),
+    ):
+        await clean_module.process(context)
+
+    context.github_project.aio_github.rest.git.async_delete_ref.assert_awaited_once_with(
+        owner="owner",
+        repo="repo",
+        ref="heads/ghci/test-bot",
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_do_not_delete_branch_when_pull_request_has_human_commit() -> None:
+    clean_module = Clean()
+    context = _make_context([_make_bot_commit(), _make_human_commit()])
+
+    with patch(
+        "githubkit.webhooks.parse_obj",
+        return_value=_make_pull_request_event(merged=False),
+    ):
+        await clean_module.process(context)
+
+    context.github_project.aio_github.rest.git.async_delete_ref.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_do_not_delete_branch_when_pull_request_is_merged() -> None:
+    clean_module = Clean()
+    context = _make_context([_make_bot_commit()])
+
+    with patch(
+        "githubkit.webhooks.parse_obj",
+        return_value=_make_pull_request_event(merged=True),
+    ):
+        await clean_module.process(context)
+
+    context.github_project.aio_github.rest.git.async_delete_ref.assert_not_called()


### PR DESCRIPTION
## Summary
- add `clean` pull request close handling to delete source branch only when the pull request is closed without merge
- ensure deletion happens only for same-repository pull requests whose commits are all bot-authored/committed, and skip default branch
- add dedicated tests covering bot-only deletion, human-commit protection, and merged pull request protection