### PR TITLE
Audit: Close pull request warning issues with title fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,5 @@ Adding an `async` to a non-async function is completely possible.
 ## Technical Terms
 
 Technical terms in Markdown files, commits, and pull requests must be enclosed in backticks.
+
+Do not add a `Validation` section in pull request descriptions.

--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -707,6 +707,7 @@ class Audit(
             await module_utils.close_pull_request_related_issues(
                 context.github_project,
                 event_data_pull_request.pull_request.number,
+                event_data_pull_request.pull_request.title,
             )
             return module.ProcessOutput(success=True)
 

--- a/github_app_geo_project/module/utils.py
+++ b/github_app_geo_project/module/utils.py
@@ -963,8 +963,14 @@ async def close_pull_request_issues(
 async def close_pull_request_related_issues(
     github_project: configuration.GithubProject,
     pull_request_number: int,
+    pull_request_title: str | None = None,
 ) -> None:
-    """Close all warning issues related to a pull request number."""
+    """Close all warning issues related to a pull request."""
+    title_start = (
+        f"{_PULL_REQUEST_ISSUE_TITLE_PREFIX}{pull_request_title} is open for "
+        if pull_request_title is not None
+        else None
+    )
     issue: githubkit.versions.latest.models.Issue
     async for issue in github_project.aio_github.paginate(
         github_project.aio_github.rest.issues.async_list_for_repo,
@@ -978,7 +984,9 @@ async def close_pull_request_related_issues(
 
         body: str = issue.body or ""
         references = {int(match.group(1)) for match in _PULL_REQUEST_REFERENCE_RE.finditer(body)}
-        if pull_request_number in references:
+        if pull_request_number in references or (
+            title_start is not None and issue.title.startswith(title_start)
+        ):
             await github_project.aio_github.rest.issues.async_update(
                 owner=github_project.owner,
                 repo=github_project.repository,

--- a/tests/test_module_audit.py
+++ b/tests/test_module_audit.py
@@ -325,6 +325,7 @@ async def test_process_close_pull_request_issues_action() -> None:
     event_data = Mock()
     event_data.pull_request = Mock()
     event_data.pull_request.number = 42
+    event_data.pull_request.title = "Audit Snyk check/fix prod-2-9-advance"
 
     with (
         patch("githubkit.webhooks.parse_obj", return_value=event_data),
@@ -335,5 +336,5 @@ async def test_process_close_pull_request_issues_action() -> None:
     ):
         result = await Audit().process(context)
 
-    mock_close_related.assert_awaited_once_with(context.github_project, 42)
+    mock_close_related.assert_awaited_once_with(context.github_project, 42, event_data.pull_request.title)
     assert result.success is True

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -260,3 +260,37 @@ async def test_close_pull_request_related_issues_close_by_pull_request_number() 
         issue_number=303,
         state="closed",
     )
+
+
+@pytest.mark.asyncio
+async def test_close_pull_request_related_issues_close_by_pull_request_title() -> None:
+    github_project = MagicMock()
+    github_project.owner = "owner"
+    github_project.repository = "repo"
+    github_project.application.slug = "my-app"
+
+    issue_to_close = MagicMock()
+    issue_to_close.title = "Pull request Audit Snyk check/fix prod-2-9-advance is open for 10 days"
+    issue_to_close.body = "No explicit pull request reference"
+    issue_to_close.number = 606
+
+    issue_other = MagicMock()
+    issue_other.title = "Pull request Audit Snyk check/fix prod-2-10 is open for 10 days"
+    issue_other.body = "No explicit pull request reference"
+    issue_other.number = 707
+
+    github_project.aio_github.paginate = MagicMock(return_value=_aiter([issue_to_close, issue_other]))
+    github_project.aio_github.rest.issues.async_update = AsyncMock()
+
+    await utils.close_pull_request_related_issues(
+        github_project,
+        42,
+        "Audit Snyk check/fix prod-2-9-advance",
+    )
+
+    github_project.aio_github.rest.issues.async_update.assert_awaited_once_with(
+        owner="owner",
+        repo="repo",
+        issue_number=606,
+        state="closed",
+    )


### PR DESCRIPTION
## Summary
- Fix audit `pull_request.closed` handling to close warning issues when the issue body no longer points to the closed pull request number.
- Add a fallback matcher based on the stable warning issue title prefix (`Pull request <title> is open for ...`) while keeping the existing `See: #<number>` matching.
- Pass the pull request title from the audit module to the issue-closing utility and add targeted tests for both matching strategies.