### PR TITLE
Audit: Trigger Renovate workflow on merged pull request close

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,10 @@ If necessary, for example for a commit that concerns only one module, use the fo
 
 Before each commit ensure that `poetry run prospector --output-format=pylint --ignore-paths=scripts` and `poetry run pytest -vv tests` do not return errors.
 
+## Pull requests
+
+The pull request description should not contain a `Testing` section.
+
 ## Future
 
 The project should fully be in async mode.

--- a/github_app_geo_project/module/audit/README.md
+++ b/github_app_geo_project/module/audit/README.md
@@ -15,6 +15,9 @@ The result will be put in the dashboard issue.
 
 This module will be triggered by the `daily` event.
 
+It also reacts to `pull_request` events with action `closed` to close related issues.
+When the pull request is merged into the default branch, it also triggers the same `Renovate` workflow as the `daily` event.
+
 ### Other files used by the module
 
 - [`SECURITY.md`](https://github.com/camptocamp/c2cciutils/wiki/SECURITY.md) from the default branch to get the stabilization branches.

--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -590,13 +590,28 @@ class Audit(
                 context.github_event_data,
             )
             if event_data_pull_request.action == "closed":
-                return [
+                actions = [
                     module.Action(
                         priority=module.PRIORITY_STANDARD,
                         data=_EventData(type="close-pull-request-issues"),
                         title="close-pull-request-issues",
                     )
                 ]
+                default_branch = context.github_event_data.get("repository", {}).get("default_branch")
+                if (
+                    event_data_pull_request.pull_request.merged
+                    and default_branch is not None
+                    and event_data_pull_request.pull_request.base.ref == default_branch
+                ):
+                    actions.append(
+                        module.Action(
+                            priority=module.PRIORITY_CRON,
+                            data=_EventData(type="renovate"),
+                            title="renovate",
+                        )
+                    )
+
+                return actions
 
         if context.module_event_name == "push":
             event_data_push = githubkit.webhooks.parse_obj(

--- a/tests/test_module_audit.py
+++ b/tests/test_module_audit.py
@@ -301,10 +301,64 @@ def test_get_actions_pull_request_closed() -> None:
     """Test that a closed pull request triggers issue closing action."""
     context = Mock()
     context.module_event_name = "pull_request"
-    context.github_event_data = {"action": "closed"}
+    context.github_event_data = {
+        "action": "closed",
+        "repository": {"default_branch": "master"},
+    }
 
     event_data = Mock()
     event_data.action = "closed"
+    event_data.pull_request = Mock()
+    event_data.pull_request.merged = False
+    event_data.pull_request.base = Mock()
+    event_data.pull_request.base.ref = "master"
+
+    with patch("githubkit.webhooks.parse_obj", return_value=event_data):
+        actions = Audit().get_actions(context)
+
+    assert len(actions) == 1
+    assert actions[0].data == _EventData(type="close-pull-request-issues")
+
+
+def test_get_actions_pull_request_closed_merged_default_branch_triggers_renovate() -> None:
+    """Test that merged pull request on default branch triggers Renovate action."""
+    context = Mock()
+    context.module_event_name = "pull_request"
+    context.github_event_data = {
+        "action": "closed",
+        "repository": {"default_branch": "master"},
+    }
+
+    event_data = Mock()
+    event_data.action = "closed"
+    event_data.pull_request = Mock()
+    event_data.pull_request.merged = True
+    event_data.pull_request.base = Mock()
+    event_data.pull_request.base.ref = "master"
+
+    with patch("githubkit.webhooks.parse_obj", return_value=event_data):
+        actions = Audit().get_actions(context)
+
+    assert len(actions) == 2
+    assert actions[0].data == _EventData(type="close-pull-request-issues")
+    assert actions[1].data == _EventData(type="renovate")
+
+
+def test_get_actions_pull_request_closed_merged_non_default_branch_no_renovate() -> None:
+    """Test that merged pull request on non-default branch does not trigger Renovate."""
+    context = Mock()
+    context.module_event_name = "pull_request"
+    context.github_event_data = {
+        "action": "closed",
+        "repository": {"default_branch": "master"},
+    }
+
+    event_data = Mock()
+    event_data.action = "closed"
+    event_data.pull_request = Mock()
+    event_data.pull_request.merged = True
+    event_data.pull_request.base = Mock()
+    event_data.pull_request.base.ref = "4.0.0"
 
     with patch("githubkit.webhooks.parse_obj", return_value=event_data):
         actions = Audit().get_actions(context)


### PR DESCRIPTION
## Summary
- Keep existing `audit` behavior on `pull_request.closed` to close related issues.
- Also enqueue the `renovate` action when the pull request is `merged` into the repository `default branch`, so the `daily` `Renovate` flow runs immediately after merge.
- Add unit tests for merged/non-merged and default/non-default branch scenarios, and document this event behavior in `audit` module `README`.
