### PR TITLE
Audit: Trigger Renovate on default branch SECURITY.md push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Before each commit ensure that `poetry run prospector --output-format=pylint --i
 
 ## Pull requests
 
-The pull request description should not contain a `Testing` section.
+The pull request description should not contain a `Testing` or `Checks` section.
 
 ## Future
 

--- a/github_app_geo_project/module/audit/README.md
+++ b/github_app_geo_project/module/audit/README.md
@@ -16,7 +16,7 @@ The result will be put in the dashboard issue.
 This module will be triggered by the `daily` event.
 
 It also reacts to `pull_request` events with action `closed` to close related issues.
-When the pull request is merged into the default branch, it also triggers the same `Renovate` workflow as the `daily` event.
+When `SECURITY.md` is changed on a `push` to the default branch, it also triggers the same `Renovate` workflow as the `daily` event.
 
 ### Other files used by the module
 

--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -590,28 +590,13 @@ class Audit(
                 context.github_event_data,
             )
             if event_data_pull_request.action == "closed":
-                actions = [
+                return [
                     module.Action(
                         priority=module.PRIORITY_STANDARD,
                         data=_EventData(type="close-pull-request-issues"),
                         title="close-pull-request-issues",
                     )
                 ]
-                default_branch = context.github_event_data.get("repository", {}).get("default_branch")
-                if (
-                    event_data_pull_request.pull_request.merged
-                    and default_branch is not None
-                    and event_data_pull_request.pull_request.base.ref == default_branch
-                ):
-                    actions.append(
-                        module.Action(
-                            priority=module.PRIORITY_CRON,
-                            data=_EventData(type="renovate"),
-                            title="renovate",
-                        )
-                    )
-
-                return actions
 
         if context.module_event_name == "push":
             event_data_push = githubkit.webhooks.parse_obj(
@@ -636,6 +621,19 @@ class Audit(
                     *(commit.modified or []),
                     *(commit.added or []),
                 ]:
+                    if event_data_push.ref == f"refs/heads/{event_data_push.repository.default_branch}":
+                        return [
+                            module.Action(
+                                priority=module.PRIORITY_CRON,
+                                data=_EventData(type="outdated"),
+                                title="outdated",
+                            ),
+                            module.Action(
+                                priority=module.PRIORITY_CRON,
+                                data=_EventData(type="renovate"),
+                                title="renovate",
+                            ),
+                        ]
                     return [
                         module.Action(
                             priority=module.PRIORITY_CRON,

--- a/tests/test_module_audit.py
+++ b/tests/test_module_audit.py
@@ -321,7 +321,7 @@ def test_get_actions_pull_request_closed() -> None:
 
 
 def test_get_actions_pull_request_closed_merged_default_branch_triggers_renovate() -> None:
-    """Test that merged pull request on default branch triggers Renovate action."""
+    """Test that merged pull request on default branch only closes related issues."""
     context = Mock()
     context.module_event_name = "pull_request"
     context.github_event_data = {
@@ -339,9 +339,8 @@ def test_get_actions_pull_request_closed_merged_default_branch_triggers_renovate
     with patch("githubkit.webhooks.parse_obj", return_value=event_data):
         actions = Audit().get_actions(context)
 
-    assert len(actions) == 2
+    assert len(actions) == 1
     assert actions[0].data == _EventData(type="close-pull-request-issues")
-    assert actions[1].data == _EventData(type="renovate")
 
 
 def test_get_actions_pull_request_closed_merged_non_default_branch_no_renovate() -> None:
@@ -392,3 +391,42 @@ async def test_process_close_pull_request_issues_action() -> None:
 
     mock_close_related.assert_awaited_once_with(context.github_project, 42, event_data.pull_request.title)
     assert result.success is True
+
+
+def test_get_actions_push_security_md_on_default_branch_triggers_renovate() -> None:
+    """Test that SECURITY.md change on default branch triggers outdated and renovate."""
+    context = Mock()
+    context.module_event_name = "push"
+    context.github_event_data = {"ref": "refs/heads/master"}
+
+    event_data = Mock()
+    event_data.commits = [Mock(modified=["SECURITY.md"], added=[], removed=[])]
+    event_data.ref = "refs/heads/master"
+    event_data.repository = Mock()
+    event_data.repository.default_branch = "master"
+
+    with patch("githubkit.webhooks.parse_obj", return_value=event_data):
+        actions = Audit().get_actions(context)
+
+    assert len(actions) == 2
+    assert actions[0].data == _EventData(type="outdated")
+    assert actions[1].data == _EventData(type="renovate")
+
+
+def test_get_actions_push_security_md_on_non_default_branch_no_renovate() -> None:
+    """Test that SECURITY.md change on non-default branch does not trigger renovate."""
+    context = Mock()
+    context.module_event_name = "push"
+    context.github_event_data = {"ref": "refs/heads/4.0.0"}
+
+    event_data = Mock()
+    event_data.commits = [Mock(modified=["SECURITY.md"], added=[], removed=[])]
+    event_data.ref = "refs/heads/4.0.0"
+    event_data.repository = Mock()
+    event_data.repository.default_branch = "master"
+
+    with patch("githubkit.webhooks.parse_obj", return_value=event_data):
+        actions = Audit().get_actions(context)
+
+    assert len(actions) == 1
+    assert actions[0].data == _EventData(type="outdated")


### PR DESCRIPTION
## Summary
- Keep `pull_request.closed` handling limited to closing related issues.
- Trigger `audit` `renovate` from `push` events when `SECURITY.md` is changed on the repository default branch.
- Add tests for `push` behavior on default/non-default branches and update `audit` module documentation.
