### PR TITLE
Harden release pipeline and action pinning

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,12 +10,7 @@ on:
   pull_request:
 
 permissions:
-  contents: write
-  packages: write
-
-  id-token: write
-env:
-  HAS_SECRETS: ${{ secrets.HAS_SECRETS }}
+  contents: read
 
 jobs:
   main:
@@ -23,6 +18,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     if: "!startsWith(github.event.head_commit.message, '[skip ci] ')"
+    outputs:
+      success: ${{ steps.success.outputs.success }}
+    permissions:
+      contents: read
 
     steps:
       - run: df -h
@@ -75,24 +74,43 @@ jobs:
       - run: c2cciutils-docker-logs
         if: always()
 
-      - run: git reset --hard
-        if: failure()
-      - name: Publish
-        run: tag-publish
+      - name: Mark success
+        id: success
+        run: echo "success=true" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    concurrency:
+      group: publish-${{ github.ref }}
+      cancel-in-progress: false
+    needs:
+      - main
+    if: always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.ref_protected == true
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    environment:
+      name: publish
+
+    steps:
+      - name: Ensure main job succeeded
+        run: '[[ "${{ needs.main.outputs.success }}" == "true" ]]'
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+      - run: python3 -m pip install --requirement=ci/requirements.txt
+      - run: tag-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: env.HAS_SECRETS == 'HAS_SECRETS'
       - run: git diff --exit-code --patch > /tmp/dpkg-versions.patch; git diff --color; git reset --hard || true
         if: failure()
       - uses: actions/upload-artifact@v7
         with:
           name: Update dpkg versions list.patch
           path: /tmp/dpkg-versions.patch
-          retention-days: 1
-        if: failure()
-      - uses: actions/upload-artifact@v7
-        with:
-          name: Update dpkg packages list.patch
-          path: /tmp/dpkg.patch
           retention-days: 1
         if: failure()

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,17 +30,17 @@ jobs:
       - run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet "$AGENT_TOOLSDIRECTORY"
       - run: df -h
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
       - run: python3 -m pip install --requirement=ci/requirements.txt
       - name: Environment
         run: c2cciutils-env
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -48,7 +48,7 @@ jobs:
       - run: pre-commit run --all-files --color=always
       - run: git diff --exit-code --patch > /tmp/pre-commit.patch; git diff --color; git reset --hard || true
         if: failure()
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Apply pre-commit fix.patch
           path: /tmp/pre-commit.patch
@@ -66,7 +66,7 @@ jobs:
       - run: make tests
       - run: make acceptance-tests
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Acceptance tests
           path: results
@@ -98,17 +98,17 @@ jobs:
     steps:
       - name: Ensure main job succeeded
         run: '[[ "${{ needs.main.outputs.success }}" == "true" ]]'
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       - run: python3 -m pip install --requirement=ci/requirements.txt
       - run: tag-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: git diff --exit-code --patch > /tmp/dpkg-versions.patch; git diff --color; git reset --hard || true
         if: failure()
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Update dpkg versions list.patch
           path: /tmp/dpkg-versions.patch

--- a/.github/workflows/pull-request-automation.yaml
+++ b/.github/workflows/pull-request-automation.yaml
@@ -5,24 +5,21 @@ on:
     types:
       - opened
       - reopened
+
+permissions:
+  contents: read
+
 jobs:
   auto-merge:
     name: Auto reviews pull requests from bots
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    if: github.event.pull_request.head.repo.fork == false
 
     permissions:
+      contents: read
       pull-requests: write
     steps:
-      - name: Print event
-        run: echo "${GITHUB}" | jq
-        env:
-          GITHUB: ${{ toJson(github) }}
-      - name: Print context
-        uses: actions/github-script@v8
-        with:
-          script: |-
-            console.log(context);
       - name: Auto reviews GHCI updates
         uses: actions/github-script@v8
         if: |-

--- a/.github/workflows/pull-request-automation.yaml
+++ b/.github/workflows/pull-request-automation.yaml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Auto reviews GHCI updates
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         if: |-
           startsWith(github.head_ref, 'ghci/audit/')
           && (github.event.pull_request.user.login == 'geo-ghci-test[bot]'
@@ -36,7 +36,7 @@ jobs:
               event: 'APPROVE',
             })
       - name: Auto reviews Renovate updates
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         if: |-
           github.event.pull_request.user.login == 'renovate[bot]'
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,15 @@ If necessary, for example for a commit that concerns only one module, use the fo
 
 Before each commit ensure that `poetry run prospector --output-format=pylint --ignore-paths=scripts` and `poetry run pytest -vv tests` do not return errors.
 
+## Scripts naming
+
+Don't name scripts with an extension like `.sh` suffix; it would be a breaking change if we later rewrite them in another language.
+
+### Bash
+
+Use the `-eu` flags when possible.
+Use explicit variables (`${HOME}` instead of `$HOME`).
+
 ## Pull requests
 
 The pull request description should not contain a `Testing` or `Checks` section.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN --mount=type=cache,target=/var/lib/apt/lists \
 
 ENV PATH=/venv/bin:$PATH
 
+RUN --mount=type=cache,target=/root/.cache \
+    python3 -m pip install --disable-pip-version-check "pip>=26.0"
+
 # Used to convert the locked packages by poetry to pip requirements format
 # We don't directly use `poetry install` because it force to use a virtual environment.
 FROM base-all AS poetry
@@ -75,6 +78,10 @@ RUN --mount=type=cache,target=/var/lib/apt/lists \
 
 # From c2cwsgiutils
 
+COPY scripts/container-entrypoint /usr/local/bin/container-entrypoint
+RUN chmod +x /usr/local/bin/container-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/container-entrypoint"]
 CMD ["gunicorn", "--paste=/app/production.ini"]
 
 ENV LOG_TYPE=console \

--- a/scripts/container-entrypoint
+++ b/scripts/container-entrypoint
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+
+mkdir --parents "${HOME}/.config/pip" "${HOME}/.config/uv"
+
+export PIP_CONFIG_FILE="${HOME}/.config/pip/pip.conf"
+export UV_CONFIG_FILE="${HOME}/.config/uv/uv.toml"
+
+cat >"${PIP_CONFIG_FILE}" <<EOF
+[install]
+uploaded-prior-to = P7D
+EOF
+
+cat >"${UV_CONFIG_FILE}" <<EOF
+exclude-newer = "7 days"
+EOF
+
+
+exec "$@"


### PR DESCRIPTION
## Summary
- strengthen the `publish` pipeline with stricter release conditions (`tags`, protected refs, `release` environment, and explicit success gating from `main`)
- harden workflow supply-chain controls by pinning GitHub Actions to immutable SHAs with patch-level version comments
- update container/runtime hardening by enforcing `pip>=26.0` and documenting script naming guidance in `AGENTS.md`