### PR TITLE
Patch: Prevent sanitizer crash on malformed patch logs

### DIFF
--- a/github_app_geo_project/module/utils.py
+++ b/github_app_geo_project/module/utils.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import datetime
+import html
 import logging
 import math
 import os
@@ -231,9 +232,55 @@ class HtmlMessage(Message):
         self.html = html
         self.title = title
 
+    @staticmethod
+    def _collapse_html(content: str, title: str, suffix: int) -> str:
+        """Wrap content in a collapse container."""
+        return "".join(
+            [
+                '<div class="collapse-container">',
+                '<p class="d-inline-flex gap-1">',
+                "<a",
+                '  class=""',
+                '  data-bs-toggle="collapse"',
+                f'  href="#element{suffix}"',
+                '  role="button"',
+                '  aria-expanded="false"',
+                f'  aria-controls="element{suffix}">',
+                '<em class="col-up bi bi-chevron-right">&nbsp;</em>',
+                '<em class="col-down bi bi-chevron-down">&nbsp;</em>',
+                title,
+                "</a>",
+                "</p>",
+                f'<div class="collapse" id="element{suffix}">',
+                content,
+                "</div>",
+                "</div>",
+            ],
+        )
+
+    def _get_escaped_fallback_html(self, style: str = "h3", collapse_suffix: int | None = None) -> str:
+        """Get a safe escaped fallback HTML representation."""
+        global _suffix  # noqa: PLW0603
+
+        escaped_html = html.escape(self.html.replace("{pre}", "").replace("{post}", ""))
+        escaped_title = html.escape(self.title)
+
+        body = f"<pre>{escaped_html}</pre>"
+        if style == "collapse" and self.title:
+            if collapse_suffix is None:
+                _suffix += 1
+                collapse_suffix = _suffix
+            return self._collapse_html(body, escaped_title, collapse_suffix)
+
+        if self.title and style != "no-title":
+            return "\n".join([f"<{style}>{escaped_title}</{style}>", body])
+
+        return body
+
     def to_html(self, style: str = "h3") -> str:
         """Convert the ANSI message to HTML."""
         global _suffix  # noqa: PLW0603
+        collapse_suffix: int | None = None
 
         # interpret template parameters
         html = self.html.replace(
@@ -246,28 +293,8 @@ class HtmlMessage(Message):
         if self.title and style != "no-title":
             if style == "collapse":
                 _suffix += 1
-                html = "".join(
-                    [
-                        '<div class="collapse-container">',
-                        '<p class="d-inline-flex gap-1">',
-                        "<a",
-                        '  class=""',
-                        '  data-bs-toggle="collapse"',
-                        f'  href="#element{_suffix}"',
-                        '  role="button"',
-                        '  aria-expanded="false"',
-                        '  aria-controls="collapseExample">',
-                        '<em class="col-up bi bi-chevron-right">&nbsp;</em>',
-                        '<em class="col-down bi bi-chevron-down">&nbsp;</em>',
-                        self.title,
-                        "</a>",
-                        "</p>",
-                        f'<div class="collapse" id="element{_suffix}">',
-                        html,
-                        "</div>",
-                        "</div>",
-                    ],
-                )
+                collapse_suffix = _suffix
+                html = self._collapse_html(html, self.title, collapse_suffix)
             else:
                 html = "\n".join([f"<{style}>{self.title}</{style}>", html])
 
@@ -308,7 +335,14 @@ class HtmlMessage(Message):
                 "keep_typographic_whitespace": True,
             },
         )
-        return cast("str", sanitizer.sanitize(html))
+        try:
+            return cast("str", sanitizer.sanitize(html))
+        except ValueError as exception:
+            _LOGGER.warning(
+                "Failed to sanitize HTML message, using escaped fallback: %s",
+                exception,
+            )
+            return self._get_escaped_fallback_html(style, collapse_suffix)
 
     def to_markdown(self, summary: bool = False) -> str:
         """Convert the ANSI message to markdown."""

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -126,6 +126,28 @@ def test_html_to_markdown() -> None:
     assert utils.html_to_markdown(html) == expected
 
 
+def test_html_message_to_html_escape_on_sanitizer_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FailingSanitizer:
+        def __init__(self, _: object) -> None:
+            pass
+
+        def sanitize(self, __: str) -> str:
+            raise ValueError("Invalid tag name")
+
+    monkeypatch.setattr(utils.html_sanitizer, "Sanitizer", _FailingSanitizer)
+    monkeypatch.setattr(utils, "_suffix", 10)
+
+    html_message = utils.HtmlMessage('<span style="color:red">broken</span> < not-a-tag', "Title <b>")
+    html = html_message.to_html(style="collapse")
+
+    assert '<div class="collapse-container">' in html
+    assert 'href="#element11"' in html
+    assert 'aria-controls="element11"' in html
+    assert '<div class="collapse" id="element11">' in html
+    assert "Title &lt;b&gt;" in html
+    assert "&lt;span style=&quot;color:red&quot;&gt;broken&lt;/span&gt; &lt; not-a-tag" in html
+
+
 def test_ansi_process_message() -> None:
     ansi_message = utils.AnsiProcessMessage(["command"], 0, "stdout\nmessage", "stderr\nmessage")
     expected_text = """Command: command


### PR DESCRIPTION
## Summary
- Add a defensive fallback in `HtmlMessage.to_html()` so a `ValueError` from `html_sanitizer` no longer aborts job processing.
- Render fallback output as escaped HTML (including escaped title) while preserving `collapse` log presentation.
- Add a unit test that simulates sanitizer failure and verifies safe escaped output.