### PR TITLE
Backport: Handle labeled pull request webhook

### DIFF
--- a/github_app_geo_project/module/backport/__init__.py
+++ b/github_app_geo_project/module/backport/__init__.py
@@ -493,10 +493,6 @@ class Backport(
             ] = list(pull_request_commits)
 
             if len(commits) != 1:
-                assert isinstance(
-                    pull_request,
-                    githubkit.versions.latest.models.PullRequestWebhook,
-                )
                 # The merge_commit_sha is no more present in the last version of the definition, get it by an other way!
                 pull_request_response = await context.github_project.aio_github.rest.pulls.async_get(
                     owner=context.github_project.owner,


### PR DESCRIPTION
## Summary

Fix the `backport` module when a backport label is added to an already merged pull request.

The `labeled` pull request webhook uses an action-specific `githubkit` pull request model, so the previous `PullRequestWebhook` assertion failed before the module could fetch the full pull request and inspect the merge commit.
