### PR TITLE
Backport: Hide tokens in logs and use typed merge commit SHA

### DIFF
--- a/github_app_geo_project/module/utils.py
+++ b/github_app_geo_project/module/utils.py
@@ -74,6 +74,19 @@ _CHECK_RE = re.compile(r"- \[([ x])\] (.*)")
 _COMMENT_RE = re.compile(r"^(.*)<!--(.*)-->(.*)$")
 _PULL_REQUEST_ISSUE_TITLE_PREFIX = "Pull request "
 _PULL_REQUEST_REFERENCE_RE = re.compile(r"(?m)^See:\s*#(\d+)\s*$")
+_COMMAND_CREDENTIAL_RE = re.compile(r"(https?://[^/@\s:]+:)([^@\s/]+)(@)")
+_X_ACCESS_TOKEN_RE = re.compile(r"(x-access-token:)([0-9a-zA-Z_.-]+)")
+_GITHUB_TOKEN_RE = re.compile(r"\b(ghs|ghp|github_pat)_[0-9a-zA-Z_]+\b")
+
+
+def _sanitize_command_argument(argument: str) -> str:
+    sanitized = _X_ACCESS_TOKEN_RE.sub(r"\1***", argument)
+    sanitized = _COMMAND_CREDENTIAL_RE.sub(r"\1***\3", sanitized)
+    return _GITHUB_TOKEN_RE.sub("***", sanitized)
+
+
+def _sanitize_command_for_log(command: list[str]) -> str:
+    return shlex.join([_sanitize_command_argument(str(argument)) for argument in command])
 
 
 def parse_dashboard_issue(issue_data: str) -> DashboardIssueRaw:
@@ -596,8 +609,9 @@ async def run_timeout(
     ------
     The standard output, the success, the logged message
     """
+    sanitized_command = _sanitize_command_for_log(command)
     log_message = "Run command: %s"
-    args: list[Any] = [shlex.join(command)]
+    args: list[Any] = [sanitized_command]
     if cwd:
         log_message += ", in %s"
         args.append(cwd)
@@ -619,7 +633,7 @@ async def run_timeout(
                 )
                 stdout, stderr = await async_proc.communicate()
             finally:
-                _LOGGER.debug("Command %s finished", shlex.join(command))
+                _LOGGER.debug("Command %s finished", sanitized_command)
             assert async_proc.returncode is not None
             message: Message = AnsiProcessMessage.from_async_artifacts(
                 command,

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -114,6 +114,21 @@ def test_AnsiMessage() -> None:
     assert markdown == "title\nmessage"
 
 
+def test_sanitize_command_for_log() -> None:
+    command = [
+        "git",
+        "clone",
+        "https://x-access-token:ghs_secretToken123@github.com/mapfish/mapfish-print.git",
+        "github_pat_0123456789ABCDEFGHIJKLMNOP",
+    ]
+
+    sanitized = utils._sanitize_command_for_log(command)
+
+    assert "ghs_secretToken123" not in sanitized
+    assert "github_pat_0123456789ABCDEFGHIJKLMNOP" not in sanitized
+    assert "x-access-token:***" in sanitized
+
+
 def test_html_to_markdown() -> None:
     html = """<span style="font-weight: bold">bold</span>
 <span style="font-style: italic">italic</span></p>


### PR DESCRIPTION
## Description
- redact command logging in `run_timeout` so credentials are masked before debug output
- fix type in backport
