### PR TITLE
Patch: Reuse command sanitization and keep token prefixes

### DIFF
--- a/github_app_geo_project/module/utils.py
+++ b/github_app_geo_project/module/utils.py
@@ -82,11 +82,15 @@ _GITHUB_TOKEN_RE = re.compile(r"\b(ghs|ghp|github_pat)_[0-9a-zA-Z_]+\b")
 def _sanitize_command_argument(argument: str) -> str:
     sanitized = _X_ACCESS_TOKEN_RE.sub(r"\1***", argument)
     sanitized = _COMMAND_CREDENTIAL_RE.sub(r"\1***\3", sanitized)
-    return _GITHUB_TOKEN_RE.sub("***", sanitized)
+    return _GITHUB_TOKEN_RE.sub(r"\1_***", sanitized)
+
+
+def _sanitize_command_arguments(command: list[str]) -> list[str]:
+    return [_sanitize_command_argument(str(argument)) for argument in command]
 
 
 def _sanitize_command_for_log(command: list[str]) -> str:
-    return shlex.join([_sanitize_command_argument(str(argument)) for argument in command])
+    return shlex.join(_sanitize_command_arguments(command))
 
 
 def parse_dashboard_issue(issue_data: str) -> DashboardIssueRaw:
@@ -449,17 +453,7 @@ class AnsiProcessMessage(AnsiMessage):
         error: str | None = None,
     ) -> None:
         """Initialize the process message."""
-        self.args: list[str] = []
-
-        args = [str(arg) for arg in args]
-
-        for arg in args:
-            if "x-access-token" in arg:
-                self.args.append(
-                    re.sub(r"x-access-token:[0-9a-zA-Z_.-]*", "x-access-token:***", arg),
-                )
-            else:
-                self.args.append(arg)
+        self.args = _sanitize_command_arguments(args)
 
         self.returncode = returncode
         if isinstance(stdout, bytes):

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -76,13 +76,27 @@ def test_dashboard_issue() -> None:
 
 def test_ProcMessage() -> None:
     proc = Mock()
-    proc.args = ["command", "arg1", "arg2", "x-access-token:123456"]
+    proc.args = [
+        "command",
+        "arg1",
+        "arg2",
+        "x-access-token:123456",
+        "https://x-access-token:ghs_secretToken123@github.com/mapfish/mapfish-print.git",
+        "github_pat_0123456789ABCDEFGHIJKLMNOP",
+    ]
     proc.returncode = 0
     proc.stdout = "stdout\nmessage"
     proc.stderr = "stderr\nmessage"
     proc_message = utils.AnsiProcessMessage(proc.args, proc.returncode, proc.stdout, proc.stderr)
 
-    assert proc_message.args == ["command", "arg1", "arg2", "x-access-token:***"]
+    assert proc_message.args == [
+        "command",
+        "arg1",
+        "arg2",
+        "x-access-token:***",
+        "https://x-access-token:***@github.com/mapfish/mapfish-print.git",
+        "github_pat_***",
+    ]
     assert proc_message.returncode == 0
     assert "stdout\nmessage" in proc_message.stdout
     assert "stderr\nmessage" in proc_message.stderr
@@ -90,7 +104,7 @@ def test_ProcMessage() -> None:
     markdown = proc_message.to_markdown()
     assert (
         markdown
-        == """Command: command arg1 arg2 'x-access-token:***'
+        == """Command: command arg1 arg2 'x-access-token:***' 'https://x-access-token:***@github.com/mapfish/mapfish-print.git' 'github_pat_***'
 Return code: 0
 
 Output:
@@ -127,6 +141,7 @@ def test_sanitize_command_for_log() -> None:
     assert "ghs_secretToken123" not in sanitized
     assert "github_pat_0123456789ABCDEFGHIJKLMNOP" not in sanitized
     assert "x-access-token:***" in sanitized
+    assert "github_pat_***" in sanitized
 
 
 def test_html_to_markdown() -> None:


### PR DESCRIPTION
This change updates command token redaction to match the expected prefix-preserving format and reuses the same sanitization logic in all command output paths.

- Keep token prefixes in masked values: ghs_\*\*\*, ghp_\*\*\*, github_pat_\*\*\*
- Reuse shared command argument sanitizer in AnsiProcessMessage
- Add and update tests for prefixed token masking and clone URL redaction