### PR TITLE
Versions: Handle date values in SECURITY.md Supported Until column

### DIFF
--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -360,9 +360,20 @@ class Versions(
                         version = raw[version_index]
                         support = raw[support_index]
                         if version in intermediate_status.version_support:
-                            intermediate_status.version_support[version] = _Support(
-                                type=_SupportType(support)
-                            )
+                            try:
+                                support_date = (
+                                    datetime.datetime.strptime(support, "%d/%m/%Y")
+                                    .astimezone(datetime.UTC)
+                                    .date()
+                                )
+                                intermediate_status.version_support[version] = _Support(
+                                    type=_SupportType.DATE,
+                                    until=support_date,
+                                )
+                            except ValueError:
+                                intermediate_status.version_support[version] = _Support(
+                                    type=_SupportType(support)
+                                )
 
             intermediate_status.stabilization_versions = stabilization_versions
 


### PR DESCRIPTION
Fix `ValueError: '23/06/2026' is not a valid _SupportType` when parsing date values from SECURITY.md.

When the 'Supported Until' column contains a date (e.g. '23/06/2026'), the code now parses it as a date and creates a _Support with type=DATE and the parsed until date, instead of passing it directly to _SupportType() which only accepts string enum values.