### PR TITLE
Redis: Add options field, remove ssl field

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,18 @@ Each GitHub application is configured via `GHCI__APPLICATION__<name>__<property>
 
 ### Other settings
 
-| Variable                | Default                  | Description                               |
-| ----------------------- | ------------------------ | ----------------------------------------- |
-| `GHCI__SERVICE_URL`     | `http://localhost:8080/` | Base URL of the service                   |
-| `GHCI__SESSION_SECRET`  | `change-me`              | Session secret key                        |
-| `GHCI__CONFIGURATION`   | `None`                   | Path to YAML configuration file           |
-| `GHCI__TEST__APP_NAME`  | `None`                   | Test application name (enables test mode) |
-| `GHCI__REDIS__HOST`     | `None`                   | Redis host                                |
-| `GHCI__REDIS__PORT`     | `6379`                   | Redis port                                |
-| `GHCI__REDIS__DB`       | `0`                      | Redis database number                     |
-| `GHCI__REDIS__USERNAME` | `None`                   | Redis username                            |
-| `GHCI__REDIS__PASSWORD` | `None`                   | Redis password                            |
-| `GHCI__REDIS__SSL`      | `False`                  | Redis SSL flag                            |
+| Variable                | Default                  | Description                                                          |
+| ----------------------- | ------------------------ | -------------------------------------------------------------------- |
+| `GHCI__SERVICE_URL`     | `http://localhost:8080/` | Base URL of the service                                              |
+| `GHCI__SESSION_SECRET`  | `change-me`              | Session secret key                                                   |
+| `GHCI__CONFIGURATION`   | `None`                   | Path to YAML configuration file                                      |
+| `GHCI__TEST__APP_NAME`  | `None`                   | Test application name (enables test mode)                            |
+| `GHCI__REDIS__HOST`     | `None`                   | Redis host                                                           |
+| `GHCI__REDIS__PORT`     | `6379`                   | Redis port                                                           |
+| `GHCI__REDIS__DB`       | `0`                      | Redis database number                                                |
+| `GHCI__REDIS__USERNAME` | `None`                   | Redis username                                                       |
+| `GHCI__REDIS__PASSWORD` | `None`                   | Redis password                                                       |
+| `GHCI__REDIS__OPTIONS`  | `None`                   | Redis connection options, e.g. `ssl_cert_reqs=None,socket_timeout=5` |
 
 ### Duration format
 

--- a/github_app_geo_project/configuration.py
+++ b/github_app_geo_project/configuration.py
@@ -133,7 +133,7 @@ async def get_github_application(application_name: str) -> GithubApplication:
                 db=settings.redis.db,
                 username=settings.redis.username,
                 password=settings.redis.password,
-                ssl=settings.redis.ssl,
+                **(settings.redis.options or {}),  # type: ignore[arg-type]
             ),
             prefix="githubkit-",
         )

--- a/github_app_geo_project/settings.py
+++ b/github_app_geo_project/settings.py
@@ -9,6 +9,7 @@ import os
 import re
 from typing import Annotated, Any, cast
 
+import yaml
 from pydantic import BaseModel, BeforeValidator, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -168,7 +169,20 @@ class _RedisSettings(BaseModel):
     db: Annotated[int, Field(description="Redis DB number")] = 0
     username: Annotated[str | None, Field(description="Redis username")] = None
     password: Annotated[str | None, Field(description="Redis password")] = None
-    ssl: Annotated[bool, Field(description="Redis SSL flag")] = False
+    options: Annotated[
+        dict[str, object] | None,
+        Field(description="Redis connection options, e.g. 'ssl_cert_reqs=None,socket_timeout=5'."),
+    ] = None
+
+    @field_validator("options", mode="before")
+    @classmethod
+    def parse_options(cls, value: str | dict[str, object] | None) -> dict[str, object] | None:
+        if value is None or isinstance(value, dict):
+            return value
+        parts = [e.strip() for e in value.split(",") if e.strip()]
+        if not parts:
+            return None
+        return {e[: e.index("=")]: yaml.safe_load(e[e.index("=") + 1 :]) for e in parts}
 
 
 class _WebhookSettings(BaseModel):


### PR DESCRIPTION
Changes:
- `settings.py`: Removed `ssl` field, added `options` field with a `field_validator` that parses a `key=value,key2=value2` string into a dict via `yaml.safe_load`
- `configuration.py`: Replaced `ssl=settings.redis.ssl` with `**(settings.redis.options or {})`
- `README.md`: Replaced `GHCI__REDIS__SSL` with `GHCI__REDIS__OPTIONS`

To fix the SSL certificate error, use:
```
GHCI__REDIS__OPTIONS=ssl_cert_reqs=none,ssl=true
```