### PR TITLE
Fix KeyError when ArmorHeaderMiddleware config has no 'headers' key

### DIFF
--- a/github_app_geo_project/app.py
+++ b/github_app_geo_project/app.py
@@ -132,7 +132,9 @@ _route_prefix = re.escape(c2casgiutils.config.settings.route_prefix.removeprefix
 app.add_middleware(
     c2casgiutils.headers.ArmorHeaderMiddleware,
     headers_config={
-        "http": {"headers": {"Strict-Transport-Security": None}} if c2casgiutils.config.settings.http else {},
+        "http": {"headers": {"Strict-Transport-Security": None}}
+        if c2casgiutils.config.settings.http
+        else {"headers": {}},
         "ui": {
             "path_match": rf"^{_route_prefix}(?:welcome|project/.*|dashboard/.*|output/[0-9]+|logs/[0-9]+)?$",
             "headers": {


### PR DESCRIPTION
Fix a KeyError that occurs when `c2casgiutils.config.settings.http` is `False` (production HTTPS mode). The `http` entry in the `headers_config` was an empty dict `{}`, but `ArmorHeaderMiddleware.__init__` expects each config entry to contain a `"headers"` key.