### PR TITLE
Make main view public with login panel for unauthenticated users

### DIFF
--- a/github_app_geo_project/app.py
+++ b/github_app_geo_project/app.py
@@ -110,8 +110,6 @@ async def _lifespan(main_app: FastAPI) -> AsyncIterator[None]:
 
 app = FastAPI(title="GitHub App Geo Project", lifespan=_lifespan)
 
-app.mount("/c2c", c2casgiutils.app)
-
 app.add_middleware(TrustedHostMiddleware, allowed_hosts=["*"])
 app.add_middleware(GZipMiddleware, minimum_size=1000)
 app.add_middleware(
@@ -127,6 +125,42 @@ route_prefix = c2casgiutils.config.settings.route_prefix
 route_prefix_escaped = re.escape(route_prefix[1:])
 _LOGGER.info("Using route prefix: '%s'", route_prefix)
 
+_Header = str | list[str] | dict[str, str] | dict[str, list[str]] | None
+_ui_csp_headers: dict[str, _Header] = {
+    "Content-Security-Policy": {
+        "default-src": ["'self'"],
+        "script-src-elem": [
+            "'self'",
+            c2casgiutils.headers.CSP_NONCE,
+            "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/",
+            "https://cdnjs.cloudflare.com/ajax/libs/jquery/",
+            "https://cdnjs.cloudflare.com/ajax/libs/popper.js/",
+        ],
+        "style-src-elem": [
+            "'self'",
+            c2casgiutils.headers.CSP_NONCE,
+            "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/",
+            "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/",
+        ],
+        "font-src": [
+            "'self'",
+            "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/",
+        ],
+        "img-src": [
+            "'self'",
+            "data:",
+        ],
+        "connect-src": [
+            "'self'",
+            "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/",
+            "https://cdnjs.cloudflare.com/ajax/libs/jquery/",
+            "https://cdnjs.cloudflare.com/ajax/libs/popper.js/",
+        ],
+    },
+}
+
+_ui_path_match = rf"^{route_prefix_escaped}(?:welcome|project/.*|dashboard/.*|output/[0-9]+|logs/[0-9]+)?$"
+
 app.add_middleware(
     c2casgiutils.headers.ArmorHeaderMiddleware,
     headers_config={
@@ -134,40 +168,14 @@ app.add_middleware(
         if c2casgiutils.config.settings.http
         else {"headers": {}},
         "ui": {
-            "path_match": rf"^{route_prefix_escaped}(?:welcome|project/.*|dashboard/.*|output/[0-9]+|logs/[0-9]+)?$",
-            "headers": {
-                "Content-Security-Policy": {
-                    "default-src": ["'self'"],
-                    "script-src-elem": [
-                        "'self'",
-                        c2casgiutils.headers.CSP_NONCE,
-                        "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/",
-                        "https://cdnjs.cloudflare.com/ajax/libs/jquery/",
-                        "https://cdnjs.cloudflare.com/ajax/libs/popper.js/",
-                    ],
-                    "style-src-elem": [
-                        "'self'",
-                        c2casgiutils.headers.CSP_NONCE,
-                        "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/",
-                        "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/",
-                    ],
-                    "font-src": [
-                        "'self'",
-                        "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/",
-                    ],
-                    "img-src": [
-                        "'self'",
-                        "data:",
-                    ],
-                    "connect-src": [
-                        "'self'",
-                        "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/",
-                        "https://cdnjs.cloudflare.com/ajax/libs/jquery/",
-                        "https://cdnjs.cloudflare.com/ajax/libs/popper.js/",
-                    ],
-                },
-            },
+            "path_match": _ui_path_match,
+            "headers": _ui_csp_headers,
             "status_code": 200,
+        },
+        "ui_302": {
+            "path_match": _ui_path_match,
+            "headers": _ui_csp_headers,
+            "status_code": 302,
         },
     },
 )

--- a/github_app_geo_project/security.py
+++ b/github_app_geo_project/security.py
@@ -4,11 +4,10 @@ import enum
 import hashlib
 import hmac
 import logging
-from typing import Annotated
 
 import c2casgiutils.config
 import githubkit
-from fastapi import Depends, HTTPException, Request
+from fastapi import Request
 from githubkit.utils import Unset
 
 from github_app_geo_project.settings import settings
@@ -106,33 +105,3 @@ async def has_repo_access(user: User, owner: str | None, repository: str | None)
     if repo.permissions is None or isinstance(repo.permissions, Unset):
         return False
     return repo.permissions.admin
-
-
-async def require_admin(
-    user: Annotated[User, Depends(get_user)],
-) -> User:
-    """Require admin access."""
-    if user.auth_type in (AuthType.GITHUB_WEBHOOK, AuthType.TEST_USER):
-        return user
-    if user.is_admin:
-        return user
-
-    raise HTTPException(status_code=403, detail="Admin access required")
-
-
-async def verify_webhook_signature(
-    user: Annotated[User, Depends(get_user)],
-) -> User:
-    """Verify the webhook signature."""
-    if user.auth_type == AuthType.GITHUB_WEBHOOK:
-        return user
-    raise HTTPException(status_code=403, detail="Invalid webhook signature")
-
-
-async def require_authenticated(
-    user: Annotated[User, Depends(get_user)],
-) -> User:
-    """Require authentication."""
-    if user.is_auth:
-        return user
-    raise HTTPException(status_code=403, detail="Authentication required")

--- a/github_app_geo_project/views/dashboard.py
+++ b/github_app_geo_project/views/dashboard.py
@@ -10,7 +10,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from github_app_geo_project import models, module
 from github_app_geo_project.module import modules
-from github_app_geo_project.security import User, require_admin
+from github_app_geo_project.security import User, get_user
 from github_app_geo_project.utils import HTML_FORMATTER
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,9 +31,17 @@ async def _render_template(renderer: str, data: dict[str, Any]) -> str:
 async def dashboard(
     request: Request,
     module_name: str,
-    user: Annotated[User, Depends(require_admin)],
+    user: Annotated[User, Depends(get_user)],
 ) -> dict[str, Any]:
     """Render the dashboard for a module."""
+    if not user.is_admin:
+        return {
+            "request": request,
+            "user": user,
+            "title": "Access Denied",
+            "html": "",
+            "styles": "",
+        }
     if module_name not in modules.MODULES:
         raise HTTPException(status_code=404, detail=f"The module {module_name} does not exist")
     module_instance = modules.MODULES[module_name]

--- a/github_app_geo_project/views/home.py
+++ b/github_app_geo_project/views/home.py
@@ -7,7 +7,7 @@ from fastapi import Depends, Request
 
 from github_app_geo_project import configuration, module
 from github_app_geo_project.module import modules
-from github_app_geo_project.security import User, require_admin
+from github_app_geo_project.security import User, get_user
 from github_app_geo_project.settings import settings
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,10 +23,10 @@ def _gt_access(
 
 async def home(
     request: Request,
-    user: Annotated[User, Depends(require_admin)],
+    user: Annotated[User, Depends(get_user)],
 ) -> dict[str, Any]:
     """Render the home page."""
-    admin = True
+    admin = user.is_admin
 
     applications: list[dict[str, Any]] = []
     for app_name, app_config in settings.application_configs.items():

--- a/github_app_geo_project/views/logs.py
+++ b/github_app_geo_project/views/logs.py
@@ -8,7 +8,7 @@ import sqlalchemy
 from fastapi import Depends, HTTPException, Query, Request
 
 from github_app_geo_project import models, utils
-from github_app_geo_project.security import User, has_repo_access, require_authenticated
+from github_app_geo_project.security import User, get_user, has_repo_access
 from github_app_geo_project.utils import HTML_FORMATTER
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ _LEVEL_RE = re.compile("^[0-9]+$")
 async def logs_view(
     request: Request,
     logs_id: int,
-    user: Annotated[User, Depends(require_authenticated)],
+    user: Annotated[User, Depends(get_user)],
     level: str = Query("", description="Filter logs by minimum level number"),
     filename: str | None = Query(None, description="Filter logs by filename regex"),
 ) -> dict[str, Any]:
@@ -34,75 +34,87 @@ async def logs_view(
         job = result.scalar()
         if job is not None:
             has_access = await has_repo_access(user, job.owner, job.repository)
-            if has_access:
-                log_query = sqlalchemy.select(models.JobLogEntry).where(
-                    models.JobLogEntry.job_id == job.id,
-                )
-
-                if _LEVEL_RE.match(level):
-                    log_query = log_query.where(models.JobLogEntry.level_no >= int(level))
-                elif level:
-                    error_messages.append("Invalid level filter")
-
-                if filename:
-                    log_query = log_query.where(
-                        models.JobLogEntry.filename.op("~")(filename),
-                    )
-
-                if not error_messages:
-                    try:
-                        log_entries_result = await session.execute(
-                            log_query.order_by(models.JobLogEntry.id),
-                        )
-                        log_entries = log_entries_result.scalars().all()
-                    except (sqlalchemy.exc.DataError, sqlalchemy.exc.ProgrammingError) as exception:
-                        _LOGGER.info(
-                            "Invalid filename filter regex for job %s: %s",
-                            job.id,
-                            exception,
-                        )
-                        error_messages.append("Invalid filename filter regex")
-                        log_entries = []
-                else:
-                    log_entries = []
-
-                css_style = None
-                if log_entries:
-                    css_style_set: set[str] = set()
-                    for entry in log_entries:
-                        if entry.css_style:
-                            css_style_set.add(entry.css_style)
-                    css_style = utils.merge_css_blocks(css_style_set)
-                    logs = "\n".join(entry.log for entry in log_entries)
-                elif level or filename:
-                    # Explicit message when filters exclude all entries.
-                    logs = "No logs match the current filters."
-                elif job.log is not None:
-                    # Fallback for legacy jobs that still store logs on the job.
-                    logs = job.log
-                else:
-                    # Ensure logs is never None, even for new jobs without entries yet.
-                    logs = ""
-
+            if not has_access:
                 return {
                     "request": request,
                     "user": user,
-                    "styles": HTML_FORMATTER.get_style_defs()
-                    + (f"\n\n/* styles form log lines */\n{css_style}" if css_style else ""),
-                    "title": title,
-                    "logs": logs,
+                    "styles": HTML_FORMATTER.get_style_defs(),
+                    "title": "Access Denied",
+                    "logs": "Access Denied",
                     "job": job,
-                    "error_message": "<br />".join(error_messages),
-                    "level_filter": level,
-                    "filename_filter": filename or "",
-                    "reload": job.status_enum in [models.JobStatus.NEW, models.JobStatus.PENDING],
-                    "favicon_postfix": (
-                        "red"
-                        if job.status_enum == models.JobStatus.ERROR
-                        else ("green" if job.status_enum == models.JobStatus.DONE else "blue")
-                    ),
+                    "error_message": "Access Denied",
+                    "level_filter": "",
+                    "filename_filter": "",
+                    "reload": False,
+                    "favicon_postfix": "red",
                 }
-            raise HTTPException(status_code=401)
+            log_query = sqlalchemy.select(models.JobLogEntry).where(
+                models.JobLogEntry.job_id == job.id,
+            )
+
+            if _LEVEL_RE.match(level):
+                log_query = log_query.where(models.JobLogEntry.level_no >= int(level))
+            elif level:
+                error_messages.append("Invalid level filter")
+
+            if filename:
+                log_query = log_query.where(
+                    models.JobLogEntry.filename.op("~")(filename),
+                )
+
+            if not error_messages:
+                try:
+                    log_entries_result = await session.execute(
+                        log_query.order_by(models.JobLogEntry.id),
+                    )
+                    log_entries = log_entries_result.scalars().all()
+                except (sqlalchemy.exc.DataError, sqlalchemy.exc.ProgrammingError) as exception:
+                    _LOGGER.info(
+                        "Invalid filename filter regex for job %s: %s",
+                        job.id,
+                        exception,
+                    )
+                    error_messages.append("Invalid filename filter regex")
+                    log_entries = []
+            else:
+                log_entries = []
+
+            css_style = None
+            if log_entries:
+                css_style_set: set[str] = set()
+                for entry in log_entries:
+                    if entry.css_style:
+                        css_style_set.add(entry.css_style)
+                css_style = utils.merge_css_blocks(css_style_set)
+                logs = "\n".join(entry.log for entry in log_entries)
+            elif level or filename:
+                # Explicit message when filters exclude all entries.
+                logs = "No logs match the current filters."
+            elif job.log is not None:
+                # Fallback for legacy jobs that still store logs on the job.
+                logs = job.log
+            else:
+                # Ensure logs is never None, even for new jobs without entries yet.
+                logs = ""
+
+            return {
+                "request": request,
+                "user": user,
+                "styles": HTML_FORMATTER.get_style_defs()
+                + (f"\n\n/* styles form log lines */\n{css_style}" if css_style else ""),
+                "title": title,
+                "logs": logs,
+                "job": job,
+                "error_message": "<br />".join(error_messages),
+                "level_filter": level,
+                "filename_filter": filename or "",
+                "reload": job.status_enum in [models.JobStatus.NEW, models.JobStatus.PENDING],
+                "favicon_postfix": (
+                    "red"
+                    if job.status_enum == models.JobStatus.ERROR
+                    else ("green" if job.status_enum == models.JobStatus.DONE else "blue")
+                ),
+            }
         raise HTTPException(status_code=404)
 
 

--- a/github_app_geo_project/views/project.py
+++ b/github_app_geo_project/views/project.py
@@ -5,7 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Annotated, Any, cast
 
 import sqlalchemy
-from fastapi import Depends, HTTPException, Query, Request
+from fastapi import Depends, Query, Request
 
 from github_app_geo_project import configuration, models, project_configuration, utils
 from github_app_geo_project.module import modules
@@ -55,7 +55,18 @@ async def project(
 ) -> dict[str, Any]:
     """Render the project page."""
     if not await has_repo_access(user, owner, repository):
-        raise HTTPException(status_code=403, detail="Access denied")
+        return {
+            "request": request,
+            "user": user,
+            "styles": HTML_FORMATTER.get_style_defs(),
+            "repository": f"{owner}/{repository}",
+            "output": [],
+            "jobs": [],
+            "error": "Access Denied",
+            "applications": {},
+            "module_configuration": [],
+            "date_tooltip": _date_tooltip,
+        }
     config: project_configuration.GithubApplicationProjectConfiguration = {}
 
     _LOGGER.debug("Configuration: %s", config)


### PR DESCRIPTION
## Changes

The home page, dashboard, and project pages now display their content publicly. When access is denied (no authentication or insufficient permissions), the page is still rendered with an Access Denied message and a login button instead of returning a raw HTTP 403/401 error. Redirect responses (302) now also receive Content-Security-Policy headers to ensure login pages load correctly.

### Details

- **app.py**: Remove duplicate /c2c mount (was mounted both with and without route_prefix), add ui_302 CSP config block for 302 responses
- **views/home.py**: `require_admin` -> `get_user`, admin features gated on `user.is_admin`
- **views/dashboard.py**: `require_admin` -> `get_user`
- **views/logs.py**: `require_authenticated` -> `get_user`, 401 -> Access Denied + login
- **views/project.py**: 403 -> Access Denied + login

<!-- pull request links -->
See JIRA issue: [GSOO-100](https://camptocamp.atlassian.net/browse/GSOO-100).