### PR TITLE
Add ForwardedHeadersMiddleware to mounted c2c sub-app to fix https URLs

### DIFF
--- a/github_app_geo_project/app.py
+++ b/github_app_geo_project/app.py
@@ -186,6 +186,11 @@ if c2casgiutils.config.settings.proxy_headers.type != "none":
         trusted_hosts=c2casgiutils.config.settings.proxy_headers.trusted_hosts,
         headers_type=c2casgiutils.config.settings.proxy_headers.type,
     )
+    c2casgiutils.app.add_middleware(
+        c2casgiutils.headers.ForwardedHeadersMiddleware,
+        trusted_hosts=c2casgiutils.config.settings.proxy_headers.trusted_hosts,
+        headers_type=c2casgiutils.config.settings.proxy_headers.type,
+    )
 
 app.mount(
     "/static",

--- a/github_app_geo_project/security.py
+++ b/github_app_geo_project/security.py
@@ -5,8 +5,10 @@ import hashlib
 import hmac
 import logging
 
+import c2casgiutils.auth
 import c2casgiutils.config
 import githubkit
+import jwt
 from fastapi import Request
 from githubkit.utils import Unset
 
@@ -83,7 +85,32 @@ async def get_user(request: Request) -> User:
             _LOGGER.warning("Invalid GitHub signature")
             user = User(AuthType.ANONYMOUS)
     else:
-        user = User(AuthType.ANONYMOUS)
+        secret = c2casgiutils.config.settings.auth.jwt.secret
+        cookie_name = c2casgiutils.config.settings.auth.jwt.cookie.name
+        if secret and cookie_name in request.cookies:
+            try:
+                user_payload = jwt.decode(
+                    request.cookies[cookie_name],
+                    secret,
+                    algorithms=[c2casgiutils.config.settings.auth.jwt.algorithm],
+                    options={"require": ["exp", "iat"]},
+                )
+                user = User(
+                    auth_type=AuthType.GITHUB_OAUTH,
+                    login=user_payload.get("login"),
+                    name=user_payload.get("display_name"),
+                    url=user_payload.get("url"),
+                    token=user_payload.get("token"),
+                    is_auth=True,
+                )
+            except jwt.ExpiredSignatureError:
+                _LOGGER.warning("Expired JWT cookie")
+                user = User(AuthType.ANONYMOUS)
+            except jwt.InvalidTokenError:
+                _LOGGER.warning("Invalid JWT cookie")
+                user = User(AuthType.ANONYMOUS)
+        else:
+            user = User(AuthType.ANONYMOUS)
 
     return user
 


### PR DESCRIPTION
The `c2casgiutils` app is mounted as a sub-app on `{route_prefix}c2c` but does not have the `ForwardedHeadersMiddleware` applied. When behind a reverse proxy that forwards requests as HTTP, `request.url_for()` calls inside `c2casgiutils` (e.g., for the OAuth callback URL) generate `http://` URLs instead of `https://`.

This adds the same `ForwardedHeadersMiddleware` to the mounted sub-app so it correctly reads the `X-Forwarded-Proto` or `Forwarded` headers and generates `https://` URLs.