### PR TITLE
Fix MissingGreenlet in finally block by refreshing job status before accessing status_enum

### DIFF
--- a/github_app_geo_project/scripts/process_queue.py
+++ b/github_app_geo_project/scripts/process_queue.py
@@ -1090,7 +1090,7 @@ async def _process_one_job(
         job.log = None
     finally:
         sentry_sdk.set_context("job", {})
-        if job.status_enum == models.JobStatus.PENDING:
+        if await session.run_sync(lambda _: job.status_enum == models.JobStatus.PENDING):
             _LOGGER.error("Job %s finished with pending status", job.id)
             job.status_enum = models.JobStatus.ERROR
         job.finished_at = datetime.datetime.now(tz=datetime.UTC)


### PR DESCRIPTION
## Description

Fix a `sqlalchemy.exc.MissingGreenlet` error that occurs in the `finally` block of `_process_one_job` when accessing `job.status_enum`.

## Root cause

When `_process_job` (or another internal function) calls `session.commit()`, all ORM attributes on `job` are expired. The `finally` block then accesses `job.status_enum`, which reads `self.status` — triggering a SQLAlchemy lazy-load that fails with `MissingGreenlet` because no async greenlet context is available at that point.

## Fix

Wrap the `job.status_enum` check in `session.run_sync()` to create a proper greenlet context for the lazy-load. Unlike `session.refresh()`, this does **not** reload the value from the database, preserving in-memory changes that may not yet be committed (e.g. the `DONE`/`ERROR` status set by the dashboard path without an intermediate `commit()`).