### PR TITLE
Use C2C__AUTH__GITHUB__REPOSITORY and ACCESS_TYPE to determine GitHub OAuth admin status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.1.0 — 2026-07-08
+## 2026-07-15
+
+### Added
+
+- **Admin access**: GitHub OAuth users can now be granted admin status based on their repository permissions. Configured via `C2C__AUTH__GITHUB__REPOSITORY` and `C2C__AUTH__GITHUB__ACCESS_TYPE` (default: `pull`). Set `C2C__AUTH__GITHUB__ACCESS_TYPE=admin` to require admin permissions on the repository.
+
+## 2026-07-08
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,16 @@ Each GitHub application is configured via `GHCI__APPLICATION__<name>__<property>
 
 ### Auth (c2casgiutils)
 
-| Variable                           | Description                             |
-| ---------------------------------- | --------------------------------------- |
-| `C2C__AUTH__GITHUB__REPOSITORY`    | GitHub repository for auth              |
-| `C2C__AUTH__GITHUB__SECRET`        | OAuth client secret                     |
-| `C2C__AUTH__GITHUB__CLIENT_ID`     | OAuth client ID                         |
-| `C2C__AUTH__GITHUB__CLIENT_SECRET` | OAuth client secret                     |
-| `C2C__AUTH__TEST__USERNAME`        | Test username (bypasses GitHub auth)    |
-| `C2C__HTTP`                        | Set to `true` to disable HTTPS redirect |
-| `C2C__PROMETHEUS__PORT`            | Prometheus metrics HTTP server port     |
+| Variable                           | Description                                                                          |
+| ---------------------------------- | ------------------------------------------------------------------------------------ |
+| `C2C__AUTH__GITHUB__REPOSITORY`    | GitHub repository for auth (also used to determine admin status)                     |
+| `C2C__AUTH__GITHUB__ACCESS_TYPE`   | Required access level for admin status: `pull`, `push`, or `admin` (default: `pull`) |
+| `C2C__AUTH__GITHUB__SECRET`        | OAuth client secret                                                                  |
+| `C2C__AUTH__GITHUB__CLIENT_ID`     | OAuth client ID                                                                      |
+| `C2C__AUTH__GITHUB__CLIENT_SECRET` | OAuth client secret                                                                  |
+| `C2C__AUTH__TEST__USERNAME`        | Test username (bypasses GitHub auth)                                                 |
+| `C2C__HTTP`                        | Set to `true` to disable HTTPS redirect                                              |
+| `C2C__PROMETHEUS__PORT`            | Prometheus metrics HTTP server port                                                  |
 
 ### Other settings
 

--- a/github_app_geo_project/security.py
+++ b/github_app_geo_project/security.py
@@ -103,6 +103,20 @@ async def get_user(request: Request) -> User:
                     token=user_payload.get("token"),
                     is_auth=True,
                 )
+                if user.token and c2casgiutils.config.settings.auth.github.repository:
+                    try:
+                        owner, repo_name = c2casgiutils.config.settings.auth.github.repository.split("/", 1)
+                        user.is_admin = await _check_repo_permission(
+                            user.token,
+                            owner,
+                            repo_name,
+                            c2casgiutils.config.settings.auth.github.access_type,
+                        )
+                    except githubkit.exception.RequestFailed:
+                        _LOGGER.warning(
+                            "Failed to check admin access for %s",
+                            c2casgiutils.config.settings.auth.github.repository,
+                        )
             except jwt.ExpiredSignatureError:
                 _LOGGER.warning("Expired JWT cookie")
                 user = User(AuthType.ANONYMOUS)
@@ -115,20 +129,31 @@ async def get_user(request: Request) -> User:
     return user
 
 
+async def _check_repo_permission(token: str, owner: str, repo: str, required_access: str) -> bool:
+    """Check if the user has the required access level on a repository."""
+    gh = githubkit.GitHub(githubkit.TokenAuthStrategy(token))
+    try:
+        repo_data = (await gh.rest.repos.async_get(owner=owner, repo=repo)).parsed_data
+    except githubkit.exception.RequestFailed as exception:
+        if exception.response.status_code == 404:
+            return False
+        _LOGGER.exception("Failed to check repository access for %s/%s", owner, repo)
+        return False
+    if repo_data.permissions is None or isinstance(repo_data.permissions, Unset):
+        return False
+    if required_access == "admin":
+        return repo_data.permissions.admin
+    if required_access == "push":
+        return repo_data.permissions.admin or repo_data.permissions.push
+    if required_access == "pull":
+        return repo_data.permissions.admin or repo_data.permissions.push or repo_data.permissions.pull
+    return False
+
+
 async def has_repo_access(user: User, owner: str | None, repository: str | None) -> bool:
     """Check if the user has admin access to the repository."""
     if user.is_admin or user.auth_type in (AuthType.GITHUB_WEBHOOK, AuthType.TEST_USER):
         return True
     if owner is None or repository is None or user.token is None:
         return False
-    gh = githubkit.GitHub(githubkit.TokenAuthStrategy(user.token))
-    try:
-        repo = (await gh.rest.repos.async_get(owner=owner, repo=repository)).parsed_data
-    except githubkit.exception.RequestFailed as exception:
-        if exception.response.status_code == 404:
-            return False
-        _LOGGER.exception("Failed to check repository access for %s/%s", owner, repository)
-        return False
-    if repo.permissions is None or isinstance(repo.permissions, Unset):
-        return False
-    return repo.permissions.admin
+    return await _check_repo_permission(user.token, owner, repository, "admin")


### PR DESCRIPTION
The GitHub OAuth user created in `get_user()` was never set as admin. This change uses the existing `c2casgiutils` auth configuration (`C2C__AUTH__GITHUB__REPOSITORY` and `C2C__AUTH__GITHUB__ACCESS_TYPE`) to determine if a GitHub OAuth user should be granted admin access.

When a user authenticates via GitHub OAuth and `C2C__AUTH__GITHUB__REPOSITORY` is configured, the application checks the user's permissions on that repository via the GitHub API. If the user's access level meets or exceeds the configured `C2C__AUTH__GITHUB__ACCESS_TYPE` (`pull`, `push`, or `admin`), they are granted `is_admin = True`.