### PR TITLE
Fix async GraphQL call in changelog module

### DIFF
--- a/github_app_geo_project/module/changelog/__init__.py
+++ b/github_app_geo_project/module/changelog/__init__.py
@@ -325,8 +325,8 @@ def get_release(
     return None
 
 
-def _get_discussion_url(github_project: GithubProject, tag: str) -> str | None:
-    categories = github_project.aio_github.graphql(
+async def _get_discussion_url(github_project: GithubProject, tag: str) -> str | None:
+    categories = await github_project.aio_github.graphql.arequest(
         """
         query DiscussionCategories($owner: String!, $name: String!) {
             repository(owner: $owner, name: $name) {
@@ -355,7 +355,7 @@ def _get_discussion_url(github_project: GithubProject, tag: str) -> str | None:
     ]
     if not category:
         return None
-    discussions_result = github_project.aio_github.graphql(
+    discussions_result = await github_project.aio_github.graphql.arequest(
         """
         query Discussion($owner: String!, $name: String!, $category: ID!) {
             repository(owner: $owner, name: $name) {
@@ -440,7 +440,7 @@ async def generate_changelog(
             raise
         milestone = milestones[0]
 
-    discussion_url = _get_discussion_url(github_project, tag_str)
+    discussion_url = await _get_discussion_url(github_project, tag_str)
 
     repository = f"{github_project.owner}/{github_project.repository}"
 


### PR DESCRIPTION
The `_get_discussion_url` function was calling the synchronous `graphql()` method on an async GitHub client configured with Redis cache, causing a `CacheUnsupportedError`.

Changes:
- Made `_get_discussion_url` an async function
- Switched from `.graphql()` to `.graphql.arequest()` with `await`
- Updated the call site in `generate_changelog` to use `await`

Closes the error:
```
CacheUnsupportedError: Async redis cache strategy does not support sync usage
```