### PR TITLE
Fix milestone creation 422 by listing closed milestones

### DIFF
--- a/github_app_geo_project/module/changelog/__init__.py
+++ b/github_app_geo_project/module/changelog/__init__.py
@@ -398,6 +398,7 @@ async def generate_changelog(
                 await github_project.aio_github.rest.issues.async_list_milestones(
                     github_project.owner,
                     github_project.repository,
+                    state="all",
                 )
             ).parsed_data,
         )
@@ -431,6 +432,7 @@ async def generate_changelog(
                     await github_project.aio_github.rest.issues.async_list_milestones(
                         github_project.owner,
                         github_project.repository,
+                        state="all",
                     )
                 ).parsed_data,
             )


### PR DESCRIPTION
## Description

When generating a changelog, if a milestone with the same title as the tag was previously closed, the `async_list_milestones` call (which defaults to `state=open`) would not find it. The code then attempts to create a new milestone with the same title, which GitHub rejects with a `422 Unprocessable Entity` because milestone titles must be unique across the entire repository (including closed milestones).

## Changes

- Add `state="all"` to both `async_list_milestones` calls in `generate_changelog` so that closed milestones are included in the search results.
- This prevents the duplicate milestone creation attempt and the resulting 422 error.