### PR TITLE
Job view: filter improvements

### DIFF
--- a/github_app_geo_project/templates/jobs.html
+++ b/github_app_geo_project/templates/jobs.html
@@ -158,7 +158,7 @@
         {% endif %}
       {% endif %}
       <a
-        href="{{ url_for('jobs_route') }}?status={{ job.status_enum.name }}{% if owner %}&owner={{ owner }}{% endif %}{% if repository %}&repository={{ repository }}{% endif %}"
+        href="{{ build_filter_url(status=job.status_enum.name) }}"
         data-bs-toggle="tooltip"
         data-bs-placement="top"
         data-bs-title="Status"
@@ -166,30 +166,30 @@
       >
       {% if show_repository %}
       <a
-        href="{{ url_for('project_route', owner=job.owner, repository=job.repository) }}"
+        href="{{ build_filter_url(owner=job.owner, repository=job.repository) }}"
         data-bs-toggle="tooltip"
         data-bs-placement="top"
-        data-bs-title="Repository"
+        data-bs-title="Filter by repository"
         >{{ job.owner }}/{{ job.repository }}</a
       >
       -
       {% endif %}
       <a
-        href="{{ url_for('jobs_route') }}?module_event_name={{ job.module_event_name }}{% if owner %}&owner={{ owner }}{% endif %}{% if repository %}&repository={{ repository }}{% endif %}"
+        href="{{ build_filter_url(module_event_name=job.module_event_name) }}"
         data-bs-toggle="tooltip"
         data-bs-placement="top"
         data-bs-title="Event name"
         >{{ job.module_event_name }}</a
       >
       <a
-        href="{{ url_for('jobs_route') }}?application={{ job.application }}{% if owner %}&owner={{ owner }}{% endif %}{% if repository %}&repository={{ repository }}{% endif %}"
+        href="{{ build_filter_url(application=job.application) }}"
         data-bs-toggle="tooltip"
         data-bs-placement="top"
         data-bs-title="Application"
         >{{ job.application }}</a
       >:<b
         ><a
-          href="{{ url_for('jobs_route') }}?module={{ job.module }}{% if owner %}&owner={{ owner }}{% endif %}{% if repository %}&repository={{ repository }}{% endif %}"
+          href="{{ build_filter_url(module=job.module) }}"
           data-bs-toggle="tooltip"
           data-bs-placement="top"
           data-bs-title="Module"

--- a/github_app_geo_project/views/jobs.py
+++ b/github_app_geo_project/views/jobs.py
@@ -37,6 +37,52 @@ def _date_tooltip(job: models.Queue) -> str:
     )
 
 
+def _build_filter_url(
+    request: Request,
+    active_filters: dict[str, str],
+    **extra: str | None,
+) -> str:
+    """Build a job filter URL preserving all active filters and adding/replacing the given extra params."""
+    params: dict[str, str] = {}
+    params.update({k: v for k, v in active_filters.items() if v})
+    params.update({k: v for k, v in extra.items() if v})
+    base_url = str(request.url_for("jobs_route"))
+    if params:
+        return base_url + "?" + "&".join(f"{k}={v}" for k, v in sorted(params.items()))
+    return base_url
+
+
+def _active_filters(
+    owner: str | None,
+    repository: str | None,
+    status: str | None,
+    github_event_name: str | None,
+    module_event_name: str | None,
+    application: str | None,
+    module: str | None,
+    limit: int,
+) -> dict[str, str]:
+    """Collect the active filters into a dict, excluding None/empty values."""
+    filters: dict[str, str] = {}
+    if owner:
+        filters["owner"] = owner
+    if repository:
+        filters["repository"] = repository
+    if status:
+        filters["status"] = status
+    if github_event_name:
+        filters["github_event_name"] = github_event_name
+    if module_event_name:
+        filters["module_event_name"] = module_event_name
+    if application:
+        filters["application"] = application
+    if module:
+        filters["module"] = module
+    if limit != 50:
+        filters["limit"] = str(limit)
+    return filters
+
+
 async def jobs_view(
     request: Request,
     user: Annotated[User, Depends(get_user)],
@@ -50,6 +96,10 @@ async def jobs_view(
     limit: int = Query(50, description="Number of jobs to show"),
 ) -> dict[str, Any]:
     """Render the jobs page listing jobs across repositories."""
+    context_filters = _active_filters(
+        owner, repository, status, github_event_name, module_event_name, application, module, limit
+    )
+
     if owner and repository:
         if not await has_repo_access(user, owner, repository):
             return {
@@ -59,8 +109,13 @@ async def jobs_view(
                 "jobs": [],
                 "owner": owner,
                 "repository": repository,
+                "status": status,
+                "application": application,
+                "module": module,
+                "limit": limit,
                 "error": "Access Denied",
                 "date_tooltip": _date_tooltip,
+                "build_filter_url": lambda **kw: _build_filter_url(request, context_filters, **kw),
                 "show_repository": False,
             }
     elif not user.is_admin:
@@ -69,10 +124,15 @@ async def jobs_view(
             "user": user,
             "styles": HTML_FORMATTER.get_style_defs(),
             "jobs": [],
-            "owner": None,
-            "repository": None,
+            "owner": owner,
+            "repository": repository,
+            "status": status,
+            "application": application,
+            "module": module,
+            "limit": limit,
             "error": "Access Denied",
             "date_tooltip": _date_tooltip,
+            "build_filter_url": lambda **kw: _build_filter_url(request, context_filters, **kw),
             "show_repository": True,
         }
 
@@ -87,13 +147,13 @@ async def jobs_view(
             select_job = select_job.where(models.Queue.repository == repository)
         if status:
             select_job = select_job.where(models.Queue.status == status)
-        if github_event_name is not None:
+        if github_event_name:
             select_job = select_job.where(models.Queue.github_event_name == github_event_name)
-        if module_event_name is not None:
+        if module_event_name:
             select_job = select_job.where(models.Queue.module_event_name == module_event_name)
-        if application is not None:
+        if application:
             select_job = select_job.where(models.Queue.application == application)
-        if module is not None:
+        if module:
             select_job = select_job.where(models.Queue.module == module)
 
         select_job = select_job.order_by(models.Queue.created_at.desc())
@@ -108,8 +168,13 @@ async def jobs_view(
             "jobs": jobs_result,
             "owner": owner,
             "repository": repository,
+            "status": status,
+            "application": application,
+            "module": module,
+            "limit": limit,
             "error": None,
             "date_tooltip": _date_tooltip,
+            "build_filter_url": lambda **kw: _build_filter_url(request, context_filters, **kw),
             "show_repository": show_repository,
         }
 


### PR DESCRIPTION
## Changes

- **Repository link**: clicking on `owner/repo` now filters jobs by that repository instead of navigating to the project page
- **Additive filters**: clicking a filter link (status, event name, application, module) now carries forward all active filters instead of only `owner` and `repository`
- **Form state**: when a filter is active, the form fields are now pre-populated with the current filter values
- **Empty filter handling**: empty filter values are no longer applied (truthy check instead of `is not None`)