### PR TITLE
Show start time in jobs, fix favicon URL

### DIFF
--- a/github_app_geo_project/app.py
+++ b/github_app_geo_project/app.py
@@ -191,7 +191,7 @@ if c2casgiutils.config.settings.proxy_headers.type != "none":
     )
 
 app.mount(
-    "/static",
+    f"{route_prefix}static",
     StaticFiles(directory="/app/github_app_geo_project/static"),
     name="static",
 )

--- a/github_app_geo_project/templates/jobs.html
+++ b/github_app_geo_project/templates/jobs.html
@@ -206,7 +206,7 @@
         data-bs-html="true"
         data-bs-title="{{ date_tooltip(job) }}"
       >
-        {{ (job.finished_at - job.started_at) | pprint_duration }}</a
+        {{ job.started_at | pprint_short_date }}</a
       >,
       {% elif job.started_at %}
       <a

--- a/github_app_geo_project/templates/jobs.html
+++ b/github_app_geo_project/templates/jobs.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <title>GitHub Application: Jobs</title>
+    <title>GHCI: Jobs</title>
     <link
       rel="icon"
       type="image/png"

--- a/github_app_geo_project/templates/project.html
+++ b/github_app_geo_project/templates/project.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <title>GitHub Application: {{ repository }}</title>
+    <title>GHCI: {{ repository }}</title>
     <link
       rel="icon"
       type="image/png"


### PR DESCRIPTION
### Changes

1. **Show start time instead of duration in jobs view** - The jobs list now shows when a job started (e.g. "11 hours ago") instead of the duration. The tooltip remains unchanged
2. **Fix favicon URL** - The static files mount now includes the `route_prefix` so that favicon URLs are generated correctly when the app is behind a route prefix