### PR TITLE
Fix job timeout check using created_at instead of started_at for pending jobs

### DIFF
--- a/github_app_geo_project/scripts/process_queue.py
+++ b/github_app_geo_project/scripts/process_queue.py
@@ -942,7 +942,7 @@ async def _get_process_one_job(
                 sqlalchemy.update(models.Queue)
                 .where(
                     models.Queue.status == models.JobStatus.PENDING.name,
-                    models.Queue.created_at < error_threshold,
+                    models.Queue.started_at < error_threshold,
                 )
                 .values(status=models.JobStatus.ERROR.name),
             )


### PR DESCRIPTION
The error threshold check in the queue processor was using `created_at` (when the job was queued) instead of `started_at` (when the job started processing).

If a changelog job spent a long time in the queue (state `NEW`) before being picked up, its `created_at` would be too old. As soon as it transitioned to `PENDING` and began executing, another worker's timeout check would immediately mark it as `ERROR` — even though the job was actively running.

Fixes `process_queue.py:944` to use `started_at` for pending jobs, matching the steal mechanism which already correctly uses `started_at`.