### PR TITLE
Audit: Do not fail the job when Snyk fix fails and show vulnerabilities in the dashboard issue

### DIFF
--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -354,6 +354,26 @@ async def _process_snyk_dpkg(
                         body_md += "\n\n"
                     body_md += f"[Output]({output_url})" if output_url is not None else ""
 
+                vuln_section_start = f"<!-- vulns-{branch} -->"
+                vuln_section_end = f"<!-- /vulns-{branch} -->"
+                found_start = None
+                found_end = None
+                for i, item in enumerate(issue_check.issue):
+                    if isinstance(item, str) and item == vuln_section_start:
+                        found_start = i
+                    if isinstance(item, str) and item == vuln_section_end:
+                        found_end = i
+                        break
+                if found_start is not None and found_end is not None:
+                    del issue_check.issue[found_start : found_end + 1]
+
+                vuln_items = [m for m in result if m.title and m.title.startswith("[")]
+                if vuln_items:
+                    issue_check.issue.append(vuln_section_start)
+                    for vuln_item in vuln_items:
+                        issue_check.issue.append(f"  - {vuln_item.title}")
+                    issue_check.issue.append(vuln_section_end)
+
             if context.module_event_data.type == "dpkg":
                 body_md = "Update dpkg packages"
 
@@ -934,6 +954,19 @@ class Audit(
             for key in list(intermediate_status.status.types.keys()):
                 if key not in all_key_starts:
                     intermediate_status.status.types.pop(key)
+                    version = key.split(" ")[-1]
+                    vuln_section_start = f"<!-- vulns-{version} -->"
+                    vuln_section_end = f"<!-- /vulns-{version} -->"
+                    found_start = None
+                    found_end = None
+                    for i, item in enumerate(issue_check.issue):
+                        if isinstance(item, str) and item == vuln_section_start:
+                            found_start = i
+                        if isinstance(item, str) and item == vuln_section_end:
+                            found_end = i
+                            break
+                    if found_start is not None and found_end is not None:
+                        del issue_check.issue[found_start : found_end + 1]
 
             # Audit is relay slow than add 15 to the cron priority
             priority = (

--- a/github_app_geo_project/module/audit/utils.py
+++ b/github_app_geo_project/module/audit/utils.py
@@ -139,9 +139,10 @@ async def snyk(
         if npm_audit_fix_message:
             assert isinstance(fix_message, module_utils.HtmlMessage)
             fix_message.html = f"{fix_message.html}<br>\n<br>\n{npm_audit_fix_message}"
-    fix_success = (
-        True if len(fixable_vulnerabilities_summary) == 0 else (snyk_fix_success and npm_audit_fix_success)
+    fix_has_errors = len(fixable_vulnerabilities_summary) > 0 and not (
+        snyk_fix_success and npm_audit_fix_success
     )
+    fix_success = True
 
     pre_commit_config = get_pre_commit_config(audit_config, audit_local_config)
     if pre_commit_config.get("enabled", True) and (cwd / ".pre-commit-config.yaml").exists():
@@ -189,7 +190,7 @@ async def snyk(
             f"{number} {severity} vulnerabilities can be fixed"
             for severity, number in fixable_vulnerabilities.items()
         ],
-        *([] if fix_success else ["Error while fixing the vulnerabilities"]),
+        *([] if not fix_has_errors else ["Error while fixing the vulnerabilities"]),
     ]
 
     return result, fix_message, return_message, fix_success
@@ -553,7 +554,7 @@ async def _snyk_test(
                 [
                     f"[{vuln['severity'].upper()}]",
                     f"{vuln['packageName']}@{vuln['version']}:",
-                    vuln["id"],
+                    f"[{vuln['id']}](https://security.snyk.io/vuln/{vuln['id']})",
                     *(vuln.get("identifiers", {}).get("CWE", [])),
                 ],
             )
@@ -684,6 +685,7 @@ async def _snyk_fix(
             )
             message.title = f"Unable to fix {len(fixable_vulnerabilities_summary)} vulnerabilities"
             _LOGGER.warning(message)
+            result.append(message)
 
     return snyk_fix_success, snyk_fix_message
 


### PR DESCRIPTION
## Changes

### 1. Do not fail the job when Snyk fix fails

In `audit/utils.py`, the `snyk()` function now always returns `fix_success=True`. The actual fix result is still tracked via `fix_has_errors` for the error message in the dashboard, but no longer causes the job to fail.

### 2. Unfixable vulnerabilities are now visible in the dashboard issue

- Vulnerability titles now include a Markdown link to the Snyk advisory page: `[SNYK-ID](https://security.snyk.io/vuln/SNYK-ID)`
- The "Unable to fix N vulnerabilities" message is now added to `result` (not only logged)
- The loop in `_process_snyk_dpkg` adds this information to `issue_check.issue` to make it visible in the GitHub dashboard issue