### PR TITLE
Fix renovate-graph dependency collection for version 0.36.0

### DIFF
--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -470,10 +470,13 @@ class Versions(
                 )
                 message.title = "Names:"
                 _LOGGER.debug(message)
+                out_dir = Path(tmpdirname) / "renovate-graph-out"
+                out_dir.mkdir(parents=True, exist_ok=True)
                 if await _get_dependencies(
                     context,
                     intermediate_status.version_dependencies_by_datasource,
                     cwd,
+                    out_dir,
                 ):
                     assert context.module_event_data.retry is not None
                     # Retry
@@ -1109,18 +1112,20 @@ async def _get_dependencies(
     context: module.ProcessContext[configuration.VersionsConfiguration, _EventData],
     result: dict[str, _TransversalStatusNameInDatasource],
     cwd: Path,
+    out_dir: Path,
 ) -> bool:
     """
     Extract dependencies using renovate-graph.
 
     This function runs renovate-graph to analyze the repository dependencies,
-    parsing its output to build a dependency graph.
+    parsing its output file to build a dependency graph.
 
     Arguments:
     ---------
         context: The process context
         result: Output dictionary to store dependency information
         cwd: The current working directory (repository root)
+        out_dir: The directory where renovate-graph will write its output file
 
     Returns
     -------
@@ -1139,13 +1144,11 @@ async def _get_dependencies(
                 "RG_LOCAL_PLATFORM": "github",
                 "RG_LOCAL_ORGANISATION": github_project.owner,
                 "RG_LOCAL_REPO": github_project.repository,
-                "RG_GITHUB_APP_ID": str(application.id),
-                "RG_GITHUB_APP_KEY": application.private_key,
                 "RENOVATE_USERNAME": username,
                 "RENOVATE_GIT_AUTHOR": f"{username} <{user.id}+{username}@users.noreply.github.com>",
-                "RG_GITHUB_APP_INSTALLATION_ID": str(user.id),
                 "GITHUB_COM_TOKEN": github_project.token,
                 "RENOVATE_REPOSITORIES": f"{github_project.owner}/{github_project.repository}",
+                "OUT_DIR": str(out_dir),
             },
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
@@ -1178,32 +1181,21 @@ async def _get_dependencies(
         message.title = "Got the dependencies"
         _LOGGER.debug(message)
 
-        lines = stdout.decode().splitlines() if stdout else []
+        output_file = out_dir / f"github-{github_project.owner}-{github_project.repository}.json"
+        if not output_file.exists():
+            message.title = "No output file found from renovate-graph"
+            _LOGGER.error(message)
+            raise VersionError(message.title)
+        async with await anyio.open_file(output_file, encoding="utf-8") as file:
+            content = await file.read()
     else:
-        lines = os.environ["RENOVATE_GRAPH"].splitlines()
+        content = os.environ["RENOVATE_GRAPH"]
 
-    index = -1
-    for i, line in enumerate(lines):
-        if line == "DEBUG: packageFiles with updates":
-            index = i + 1
-            break
-    if index != -1:
-        lines = lines[index:]
-
-    index = -1
-    for i, line in enumerate(lines):
-        if not line.startswith("       "):
-            index = i
-            break
-    if index != -1:
-        lines = lines[:index]
-
-    json_str = "{\n" + "\n".join(lines) + "\n}"
-    message = module_utils.HtmlMessage(utils.format_json_str(json_str))
+    message = module_utils.HtmlMessage(utils.format_json_str(content))
     message.title = "Read dependencies from"
     _LOGGER.debug(message)
-    data = json.loads(json_str)
-    _read_dependencies(context, data, result)
+    data = json.loads(content)
+    _read_dependencies(context, {"config": data.get("packageData", {})}, result)
     return False
 
 

--- a/tests/test_module_versions.py
+++ b/tests/test_module_versions.py
@@ -69,37 +69,39 @@ async def test_process_step_2() -> None:
     repos.async_get_content.side_effect = githubkit.exception.RequestFailed(response)
 
     os.environ["TEST"] = "TRUE"
-    os.environ["RENOVATE_GRAPH"] = json.dumps({
-        "repo": "test",
-        "organisation": "camptocamp",
-        "packageData": {
-            "docker-compose": [
-                {
-                    "deps": [
-                        {
-                            "depName": "actions/checkout",
-                            "commitMessageTopic": "{{{depName}}} action",
-                            "datasource": "github-tags",
-                            "versioning": "docker",
-                            "depType": "action",
-                            "replaceString": "actions/checkout@v4",
-                            "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
-                            "currentValue": "v4",
-                            "skipReason": "github-token-required",
-                        }
-                    ],
-                    "packageFile": "docker-compose.yaml",
+    os.environ["RENOVATE_GRAPH"] = json.dumps(
+        {
+            "repo": "test",
+            "organisation": "camptocamp",
+            "packageData": {
+                "docker-compose": [
+                    {
+                        "deps": [
+                            {
+                                "depName": "actions/checkout",
+                                "commitMessageTopic": "{{{depName}}} action",
+                                "datasource": "github-tags",
+                                "versioning": "docker",
+                                "depType": "action",
+                                "replaceString": "actions/checkout@v4",
+                                "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+                                "currentValue": "v4",
+                                "skipReason": "github-token-required",
+                            }
+                        ],
+                        "packageFile": "docker-compose.yaml",
+                    }
+                ]
+            },
+            "metadata": {
+                "renovate": {
+                    "platform": "github",
+                    "version": "42.92.5",
+                    "major": 42,
                 }
-            ]
-        },
-        "metadata": {
-            "renovate": {
-                "platform": "github",
-                "version": "42.92.5",
-                "major": 42,
-            }
-        },
-    })
+            },
+        }
+    )
     output = await versions.process(context)
     assert output.updated_transversal_status is True
     assert isinstance(output.intermediate_status, _IntermediateStatus)

--- a/tests/test_module_versions.py
+++ b/tests/test_module_versions.py
@@ -69,43 +69,37 @@ async def test_process_step_2() -> None:
     repos.async_get_content.side_effect = githubkit.exception.RequestFailed(response)
 
     os.environ["TEST"] = "TRUE"
-    os.environ["RENOVATE_GRAPH"] = """
-DEBUG: Found sourceUrl with multiple branches that should probably be combined into a group
-       "sourceUrl": "https://github.com/eslint/eslint",
-       "newVersion": "9.26.0",
-       "branches": {"renovate/eslint-js-9.x": "@eslint/js", "renovate/eslint-9.x": "eslint"}
-DEBUG: packageFiles with updates
-       "config": {
-         "docker-compose": [
-           {
-             "deps": [
-               {
-                 "depName": "actions/checkout",
-                 "commitMessageTopic": "{{{depName}}} action",
-                 "datasource": "github-tags",
-                 "versioning": "docker",
-                 "depType": "action",
-                 "replaceString": "actions/checkout@v4",
-                 "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
-                 "currentValue": "v4",
-                 "skipReason": "github-token-required"
-               }
-             ],
-             "packageFile": "docker-compose.yaml"
-           }
-         ]
-        }
- WARN: The repository name for {"mode":"full","allowedHeaders":["X-*"],"autodiscoverRepoOrder":null, ...,"regex":{"pinDigests":false},"jsonata":{"pinDigests":false}} was not defined, skipping
-DEBUG: defaultWritePackageDataCallback called for local/camptocamp/c2cgeoportal
-       "key": {"platform": "local", "organisation": "camptocamp", "repo": "c2cgeoportal"}
-DEBUG: writePackageDataToFile called for local/camptocamp/c2cgeoportal
-       "key": {"platform": "local", "organisation": "camptocamp", "repo": "c2cgeoportal"},
-       "outDir": "out"
- WARN: writePackageDataToFile called for local/camptocamp/c2cgeoportal, but there was no `packageDataDump` provided, likely because the repository failed to scan. Check the logs
-       "key": {"platform": "local", "organisation": "camptocamp", "repo": "c2cgeoportal"},
-       "outDir": "out"
-DEBUG: Determining if we should process repository camptocamp/tilecloud, using GitHub App authentication (repository=camptocamp/tilecloud)
-"""
+    os.environ["RENOVATE_GRAPH"] = json.dumps({
+        "repo": "test",
+        "organisation": "camptocamp",
+        "packageData": {
+            "docker-compose": [
+                {
+                    "deps": [
+                        {
+                            "depName": "actions/checkout",
+                            "commitMessageTopic": "{{{depName}}} action",
+                            "datasource": "github-tags",
+                            "versioning": "docker",
+                            "depType": "action",
+                            "replaceString": "actions/checkout@v4",
+                            "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+                            "currentValue": "v4",
+                            "skipReason": "github-token-required",
+                        }
+                    ],
+                    "packageFile": "docker-compose.yaml",
+                }
+            ]
+        },
+        "metadata": {
+            "renovate": {
+                "platform": "github",
+                "version": "42.92.5",
+                "major": 42,
+            }
+        },
+    })
     output = await versions.process(context)
     assert output.updated_transversal_status is True
     assert isinstance(output.intermediate_status, _IntermediateStatus)


### PR DESCRIPTION
Update `_get_dependencies` for `renovate-graph` 0.36.0 which changed its output format:

- Remove `RG_GITHUB_APP_ID` / `RG_GITHUB_APP_KEY` / `RG_GITHUB_APP_INSTALLATION_ID` env vars that triggered the GitHub App authentication path instead of the local command-line path, breaking `--platform=local`.
- Add `OUT_DIR` env var pointing to a temp directory.
- Read the output JSON file from `OUT_DIR` instead of parsing stdout for `"DEBUG: packageFiles with updates"`.
- Update test data to match the new output format (`{ repo, organisation, packageData, metadata }`).