### PR TITLE
Suppress configurable logger names from DB logs

### DIFF
--- a/github_app_geo_project/scripts/process_queue.py
+++ b/github_app_geo_project/scripts/process_queue.py
@@ -70,11 +70,13 @@ _FLUSH_LOCK = asyncio.Lock()
 class _Handler(logging.Handler):
     context_var: contextvars.ContextVar[int] = contextvars.ContextVar("job_id")
 
-    def __init__(self, job_id: int) -> None:
+    def __init__(self, job_id: int, suppressed_logger_names: list[str], suppressed_logger_level: str) -> None:
         super().__init__()
         self.results: list[tuple[logging.LogRecord, str | None]] = []
         self.last_written_index = 0
         self.job_id = job_id
+        self.suppressed_logger_names = suppressed_logger_names
+        self.suppressed_logger_level = logging.getLevelName(suppressed_logger_level)
         self.context_var.set(job_id)
 
     def emit(self, record: logging.LogRecord) -> None:
@@ -82,6 +84,11 @@ class _Handler(logging.Handler):
             if self.context_var.get() != self.job_id:
                 return
         except LookupError:
+            return
+        if (
+            record.levelno <= self.suppressed_logger_level
+            and any(record.name.startswith(prefix) for prefix in self.suppressed_logger_names)
+        ):
             return
         css_style = None
         if isinstance(record.msg, module_utils.Message):
@@ -1012,7 +1019,11 @@ async def _process_one_job(
     # Capture_logs
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
-    handler = _Handler(job.id)
+    handler = _Handler(
+        job.id,
+        settings.process_queue.suppressed_logger_names,
+        settings.process_queue.suppressed_logger_level,
+    )
     handler.setFormatter(
         _Formatter("%(levelname)-5.5s %(pathname)s:%(lineno)d %(funcName)s()"),
     )

--- a/github_app_geo_project/scripts/process_queue.py
+++ b/github_app_geo_project/scripts/process_queue.py
@@ -85,9 +85,8 @@ class _Handler(logging.Handler):
                 return
         except LookupError:
             return
-        if (
-            record.levelno <= self.suppressed_logger_level
-            and any(record.name.startswith(prefix) for prefix in self.suppressed_logger_names)
+        if record.levelno <= self.suppressed_logger_level and any(
+            record.name.startswith(prefix) for prefix in self.suppressed_logger_names
         ):
             return
         css_style = None

--- a/github_app_geo_project/settings.py
+++ b/github_app_geo_project/settings.py
@@ -152,6 +152,15 @@ class _ProcessQueueSettings(BaseModel):
     )
     priority_groups: Annotated[str, Field(description="Priority groups")] = "2147483647"
     socket_timeout: Annotated[Duration, Field(description="Socket timeout")] = datetime.timedelta(minutes=2)
+    suppressed_logger_names: Annotated[
+        list[str], Field(description="Logger names to suppress from DB logs")
+    ] = ["asyncio", "hishel", "httpcore"]
+    suppressed_logger_level: Annotated[
+        str,
+        Field(
+            description="Log level name to suppress and below (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+        ),
+    ] = "DEBUG"
 
 
 class _C2cciutilsSettings(BaseModel):


### PR DESCRIPTION
**Summary**\nAdd the ability to suppress debug (or configurable level) logs from specific loggers (e.g. asyncio) in the database log table.\n\n**Context**\nDEBUG logs from chatty modules like asyncio were filling the `job_log` table with noise.\n\n**Implementation Details**\n- Added two new settings in `_ProcessQueueSettings`:\n  - `suppressed_logger_names` (default: `["asyncio"]`)\n  - `suppressed_logger_level` (default: `10` = DEBUG)\n- The `_Handler.emit()` method now skips records where `record.levelno <= suppressed_logger_level` AND `record.name` starts with any of the suppressed logger prefixes.\n- Configurable via environment variables: `GHCI__PROCESS_QUEUE__SUPPRESSED_LOGGER_NAMES` and `GHCI__PROCESS_QUEUE__SUPPRESSED_LOGGER_LEVEL`.\n\n**Impact/Risks**\nLow risk. The default behavior suppresses only DEBUG-level asyncio logs, which were noise anyway.