### PR TITLE
Add logger_name to JobLogEntry

### DIFF
--- a/github_app_geo_project/models.py
+++ b/github_app_geo_project/models.py
@@ -123,6 +123,7 @@ class JobLogEntry(Base):
     job: Mapped[Queue] = relationship("Queue", back_populates="logs")
     level_name: Mapped[str] = mapped_column(Unicode, nullable=False, index=True)
     level_no: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    logger_name: Mapped[str] = mapped_column(Unicode, nullable=False, index=True)
     filename: Mapped[str] = mapped_column(Unicode, nullable=False, index=True)
     log: Mapped[str] = mapped_column(Unicode, nullable=False)
     css_style: Mapped[str | None] = mapped_column(Unicode, nullable=True)

--- a/github_app_geo_project/scripts/process_queue.py
+++ b/github_app_geo_project/scripts/process_queue.py
@@ -134,6 +134,7 @@ async def _flush_job_logs(
                         css_style=css_style,
                         level_name=entry.levelname,
                         level_no=entry.levelno,
+                        logger_name=entry.name,
                         filename=entry.pathname,
                     )
                 )


### PR DESCRIPTION
**Summary**

Add the logger name (`entry.name`) to the `JobLogEntry` database model, so each log entry records which logger produced it (e.g., `github_app_geo_project.module.cache_clean`).

**Context**

- The `LogRecord.name` attribute was already available in the `_flush_job_logs` handler but was not persisted to the database.
- This allows filtering logs by module name in the future.

**Implementation Details**

- Added `logger_name` column to `JobLogEntry` model in `models.py` (Unicode, not null, indexed).
- Updated `_flush_job_logs` in `process_queue.py` to save `entry.name` to the new column.