### PR TITLE
Audit: Fix paginator for security advisories API

### DIFF
--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -652,7 +652,7 @@ async def _create_security_advisories(
         # List existing advisories to avoid duplicates
         existing_advisory_ids: set[str] = set()
         try:
-            async for advisory in context.github_project.aio_github.paginate(
+            async for advisory in context.github_project.aio_github.rest.paginate(
                 context.github_project.aio_github.rest.security_advisories.async_list_repository_advisories,
                 owner=context.github_project.owner,
                 repo=context.github_project.repository,


### PR DESCRIPTION
## Summary

Fix a TypeError when creating security advisories by using the correct paginator.

## Context

The legacy `aio_github.paginate()` injects a `page` parameter into API calls, but `async_list_repository_advisories` does not accept a `page` parameter — it uses cursor-based pagination (`before`/`after`). This caused a `TypeError` at runtime.

## Implementation Details

Replaced `aio_github.paginate()` with `aio_github.rest.paginate()` on the single call that lists repository security advisories. The new paginator follows `Link` header `rel="next"` URLs and does not inject `page=`.