### PR TITLE
Move CVEs from GitHub issue dashboard to transversal dashboard

### DIFF
--- a/AUDIT-CONFIG.md
+++ b/AUDIT-CONFIG.md
@@ -8,9 +8,9 @@
     - <a id="properties/audit/properties/snyk/properties/enabled"></a>**`enabled`** *(boolean)*: Enable Snyk audit. Default: `true`.
     - <a id="properties/audit/properties/snyk/properties/files-no-install"></a>**`files-no-install`** *(array)*: Dependency files that will not be installed. Default: `[]`.
       - <a id="properties/audit/properties/snyk/properties/files-no-install/items"></a>**Items** *(string)*
-    - <a id="properties/audit/properties/snyk/properties/excluded-files"></a>**`excluded-files`** *(array)*: List of regex patterns for file names to exclude from the dashboard and security advisories. Default: `[]`.
+    - <a id="properties/audit/properties/snyk/properties/excluded-files"></a>**`excluded-files`** *(array)*: List of regex patterns for file names to exclude from the transversal dashboard and security advisories. Default: `[]`.
       - <a id="properties/audit/properties/snyk/properties/excluded-files/items"></a>**Items** *(string)*
-    - <a id="properties/audit/properties/snyk/properties/dashboard-severity-threshold"></a>**`dashboard-severity-threshold`** *(string)*: Minimum severity level to display on the dashboard (low, medium, high, critical). Must be one of: "low", "medium", "high", or "critical". Default: `"medium"`.
+    - <a id="properties/audit/properties/snyk/properties/dashboard-severity-threshold"></a>**`dashboard-severity-threshold`** *(string)*: Minimum severity level to display on the transversal dashboard (low, medium, high, critical). Must be one of: "low", "medium", "high", or "critical". Default: `"medium"`.
     - <a id="properties/audit/properties/snyk/properties/advisory-severity-threshold"></a>**`advisory-severity-threshold`** *(string)*: Minimum severity level to create a GitHub Security Advisory (low, medium, high, critical). Must be one of: "low", "medium", "high", or "critical". Default: `"high"`.
     - <a id="properties/audit/properties/snyk/properties/pip-install-arguments"></a>**`pip-install-arguments`** *(array)*: Arguments to pass to pip install. Default: `[]`.
       - <a id="properties/audit/properties/snyk/properties/pip-install-arguments/items"></a>**Items** *(string)*

--- a/github_app_geo_project/module/audit/README.md
+++ b/github_app_geo_project/module/audit/README.md
@@ -9,7 +9,7 @@ A module that does some audit stuff on the project:
 
 Currently, the module checks the CVEs on the dependencies, but it does not check the code neither the generated Docker images.
 
-The result will be put in the dashboard issue.
+The result will be put in the transversal dashboard.
 
 ### Events
 
@@ -28,7 +28,7 @@ When `SECURITY.md` is changed on a `push` to the default branch, it also trigger
 
 #### Vulnerability Scanning
 
-The module uses Snyk to scan for vulnerabilities in project dependencies. It focuses on identifying critical security issues that need immediate attention. The scan results are aggregated and reported in the dashboard issue.
+The module uses Snyk to scan for vulnerabilities in project dependencies. It focuses on identifying critical security issues that need immediate attention. The scan results are aggregated and reported in the transversal dashboard.
 
 #### Automatic Fix Pull Requests
 
@@ -48,17 +48,14 @@ You can configure the audit module behavior through the `.github/ghci.yaml` file
 
 [Configuration reference](https://github.com/camptocamp/github-app-geo-project/blob/master/AUDIT-CONFIG.md).
 
-#### Dashboard Display
+#### Transversal Dashboard
 
-The vulnerability dashboard uses the following format:
-
-- `=== <branch>` — section header for each stabilization branch
-- `==== <file_name>` — sub-header for each dependency file (e.g., `requirements.txt`, `package-lock.json`)
+The vulnerability dashboard is displayed on the web UI at `/dashboard/audit` (the transversal dashboard).
 
 You can control which vulnerabilities appear on the dashboard with:
 
-- `snyk.dashboard-severity-threshold` — minimum severity level to display (default: `medium`)
-- `snyk.excluded-files` — list of regex patterns for file names to exclude from the dashboard
+- `snyk.dashboard-severity-threshold` — minimum severity level to display on the transversal dashboard (default: `medium`)
+- `snyk.excluded-files` — list of regex patterns for file names to exclude from the transversal dashboard
 
 #### Security Advisories
 

--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -46,8 +46,27 @@ class _TransversalStatusTool(BaseModel):
     title: str
 
 
+class _VulnerabilityStatus(BaseModel):
+    """Vulnerability data stored in transversal status."""
+
+    file: str
+    package_name: str
+    package_version: str
+    package_manager: str
+    severity: str
+    snyk_id: str
+    cve_ids: list[str] = []
+    cwe_ids: list[str] = []
+    title: str
+    fixed_in: list[str] = []
+    is_upgradable: bool = False
+    is_patchable: bool = False
+
+
 class _TransversalStatusRepo(BaseModel):
     types: dict[str, _TransversalStatusTool] = {}
+    vulnerabilities: dict[str, dict[str, list[_VulnerabilityStatus]]] = {}
+    """Branch -> file_name -> list of vulnerability data"""
 
 
 class _TransversalStatus(BaseModel):
@@ -412,7 +431,7 @@ async def _process_snyk_dpkg(
                 min_dashboard_severity = audit_utils.SEVERITY_ORDER.get(dashboard_threshold, 1)
                 min_advisory_severity = audit_utils.SEVERITY_ORDER.get(advisory_threshold, 2)
 
-                # Filter vulnerabilities by excluded files and dashboard threshold
+                # Filter vulnerabilities by excluded files and thresholds
                 filtered_vulns: dict[str, list[audit_utils.VulnerabilityData]] = {}
                 high_critical_vulns: list[audit_utils.VulnerabilityData] = []
                 for file_name, vulns in file_vulnerabilities.items():
@@ -426,11 +445,10 @@ async def _process_snyk_dpkg(
                             high_critical_vulns.append(vuln)
 
                 if filtered_vulns:
-                    issue_check.issue.append(vuln_title)
-                    for file_name, vulns in sorted(filtered_vulns.items()):
-                        issue_check.issue.append(f"==== {file_name}")
-                        for vuln in vulns:
-                            issue_check.issue.append(f"  - {vuln.title}")
+                    intermediate_status.status.vulnerabilities[branch] = {
+                        file_name: [_VulnerabilityStatus(**vuln._asdict()) for vuln in vulns]
+                        for file_name, vulns in sorted(filtered_vulns.items())
+                    }
 
                 # Create security advisories for HIGH and CRITICAL CVEs
                 if high_critical_vulns:

--- a/github_app_geo_project/module/audit/configuration.py
+++ b/github_app_geo_project/module/audit/configuration.py
@@ -76,7 +76,7 @@ DashboardSeverityThreshold = Literal['low'] | Literal['medium'] | Literal['high'
 r"""
 Dashboard severity threshold.
 
-Minimum severity level to display on the dashboard (low, medium, high, critical)
+Minimum severity level to display on the transversal dashboard (low, medium, high, critical)
 
 default: medium
 """
@@ -318,14 +318,14 @@ SnykConfiguration = TypedDict('SnykConfiguration', {
     'files-no-install': list[str],
     # | Excluded files.
     # | 
-    # | List of regex patterns for file names to exclude from the dashboard and security advisories
+    # | List of regex patterns for file names to exclude from the transversal dashboard and security advisories
     # | 
     # | default:
     # |   []
     'excluded-files': list[str],
     # | Dashboard severity threshold.
     # | 
-    # | Minimum severity level to display on the dashboard (low, medium, high, critical)
+    # | Minimum severity level to display on the transversal dashboard (low, medium, high, critical)
     # | 
     # | default: medium
     'dashboard-severity-threshold': "DashboardSeverityThreshold",

--- a/github_app_geo_project/module/audit/dashboard.html
+++ b/github_app_geo_project/module/audit/dashboard.html
@@ -6,4 +6,21 @@
 <!---->
 {% endfor %}
 <!---->
+{% if data['data'].vulnerabilities %}
+<h3>Vulnerabilities</h3>
+{% for branch_name, files in data['data'].vulnerabilities.items() %}
+<h4>{{ branch_name }}</h4>
+{% for file_name, vulns in files.items() %}
+<h5>{{ file_name }}</h5>
+<ul>
+  {% for vuln in vulns %}
+  <li>{{ vuln.title }}</li>
+  {% endfor %}
+</ul>
+{% endfor %}
+<!---->
+{% endfor %}
+<!---->
+{% endif %}
+<!---->
 {% endfor %}

--- a/github_app_geo_project/module/audit/schema.json
+++ b/github_app_geo_project/module/audit/schema.json
@@ -38,7 +38,7 @@
             "excluded-files": {
               "type": "array",
               "title": "Excluded files",
-              "description": "List of regex patterns for file names to exclude from the dashboard and security advisories",
+              "description": "List of regex patterns for file names to exclude from the transversal dashboard and security advisories",
               "default": [],
               "items": {
                 "type": "string"
@@ -47,7 +47,7 @@
             "dashboard-severity-threshold": {
               "type": "string",
               "title": "Dashboard severity threshold",
-              "description": "Minimum severity level to display on the dashboard (low, medium, high, critical)",
+              "description": "Minimum severity level to display on the transversal dashboard (low, medium, high, critical)",
               "default": "medium",
               "enum": ["low", "medium", "high", "critical"]
             },


### PR DESCRIPTION
## Summary

Remove vulnerability details from the GitHub issue body and display them in the transversal dashboard web UI instead.

## Context

Previously, CVE vulnerability details were written directly into the repository's GitHub issue dashboard body under `=== branch` and `==== file` headers. This made the issue body very large and hard to navigate. Instead, these details are now stored in the transversal status and displayed on the web UI at `/dashboard/audit`.

## Implementation Details

- Added `_VulnerabilityStatus` Pydantic model and `vulnerabilities` field to `_TransversalStatusRepo` for storing vulnerability data per branch/file
- Removed the block that wrote `=== branch`, `==== file`, and individual vulnerability lines to `DashboardIssue.issue` (the GitHub issue body)
- Store filtered vulnerabilities in `intermediate_status.status.vulnerabilities` so they propagate to the transversal dashboard
- Updated `dashboard.html` Jinja2 template to render vulnerability data by repository, branch, and file
- Kept the old cleanup code for backward compatibility (removes stale vulnerability sections from existing dashboards)
- Updated schema and config descriptions to clarify \"dashboard\" now refers to the transversal dashboard

## Impact/Risks

- Low risk: all existing filtering (`dashboard-severity-threshold`, `excluded-files`, `advisory-severity-threshold`) continues to work as before
- The GitHub issue dashboard will no longer show individual CVE lines, reducing issue body size