### PR TITLE
Fix: Sanitize publisher field in RepositoryAdvisory paginator to avoid Pydantic ValidationError

### DIFF
--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -20,6 +20,8 @@ import githubkit.webhooks
 import githubkit_schemas.latest.models
 import security_md
 import yaml
+from githubkit.compat import type_validate_python
+from githubkit_schemas.v2026_03_10.models import RepositoryAdvisory
 from githubkit_schemas.v2026_03_10.types import (
     RepositoryAdvisoryCreatePropVulnerabilitiesItemsPropPackageType,
     RepositoryAdvisoryCreatePropVulnerabilitiesItemsType,
@@ -650,12 +652,20 @@ async def _create_security_advisories(
     """Create GitHub Security Advisories for the given vulnerabilities."""
     # List existing advisories to avoid duplicates
     existing_advisory_ids: set[str] = set()
-    async for advisory in context.github_project.aio_github.rest.paginate(
+    paginator = context.github_project.aio_github.rest.paginate(
         context.github_project.aio_github.rest.security_advisories.async_list_repository_advisories,
+        map_func=lambda response: type_validate_python(
+            list[RepositoryAdvisory],
+            [
+                {**item, "publisher": None} if item.get("publisher") is not None else item
+                for item in response.json()
+            ],
+        ),
         owner=context.github_project.owner,
         repo=context.github_project.repository,
         state="published",
-    ):
+    )
+    async for advisory in paginator:
         if advisory.identifiers:
             for identifier in advisory.identifiers:
                 if identifier.type == "CVE":


### PR DESCRIPTION
## Summary

Fix a Pydantic `ValidationError` when listing repository advisories: GitHub's API now returns a non-null `publisher` object, but the `RepositoryAdvisory` model (from `githubkit-schemas` 2026-03-10) expects it to be `null`.

## Context

- The `publisher` field in the `RepositoryAdvisory` model is typed as `None`, but GitHub's API returns a `SimpleUser` object (e.g. `{"login": "sbrunner", ...}`)
- This causes `pydantic_core.ValidationError: Input should be null`

## Implementation Details

- Added a `map_func` to the paginator that sanitizes the `publisher` field to `None` before Pydantic validation
- Updated `githubkit-schemas` from `26.6.20` to `26.7.11` (already specified in `pyproject.toml`/`poetry.lock`)
- The `map_func` uses `response.json()` to get raw JSON, sets `publisher` to `None` where non-null, then validates with `type_validate_python(list[RepositoryAdvisory], ...)`

## Impact/Risks

- Low risk: only affects the advisory listing in the audit module
- Backward compatible: the typed model contract is preserved