### PR TITLE
Audit dashboard: group types by branch, color severity, always show output link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,10 @@ Use explicit variables (`${HOME}` instead of `$HOME`).
 
 The pull request description should not contain a `Testing` or `Checks` section.
 
+## Jinja templates
+
+In Jinja templates, add `<!---->` between two Jinja directives (`{% ... %}`) to ensure they are on separate lines despite Prettier formatting.
+
 ## Async rules
 
 The project should fully be in async mode.

--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -1273,13 +1273,32 @@ class Audit(
         """Get the transversal dashboard content."""
         repositories = []
         for repository, data in context.status.repositories.items():
-            if data:
-                repositories.append(
-                    {
-                        "repository": repository,
-                        "data": data,
-                    },
-                )
+            if not (data.types or data.vulnerabilities):
+                continue
+
+            global_types = []
+            branches: dict[str, Any] = {}
+            for type_key, type_data in data.types.items():
+                if type_key == _OUTDATED:
+                    global_types.append({"name": type_key, "title": type_data.title})
+                else:
+                    parts = type_key.rsplit(" ", 1)
+                    if len(parts) > 1:
+                        branch_name = parts[-1]
+                        branch = branches.setdefault(branch_name, {"types": [], "vulnerabilities": {}})
+                        branch["types"].append({"name": type_key, "title": type_data.title})
+
+            for branch_name, vulns in data.vulnerabilities.items():
+                branch = branches.setdefault(branch_name, {"types": [], "vulnerabilities": {}})
+                branch["vulnerabilities"] = vulns
+
+            repositories.append(
+                {
+                    "repository": repository,
+                    "global_types": global_types,
+                    "branches": [{"name": b, **branches[b]} for b in sorted(branches.keys())],
+                },
+            )
         return module.TransversalDashboardOutput(
             renderer="github_app_geo_project:module/audit/dashboard.html",
             data={"repositories": repositories},

--- a/github_app_geo_project/module/audit/dashboard.html
+++ b/github_app_geo_project/module/audit/dashboard.html
@@ -1,26 +1,44 @@
-{% for data in repositories %}
-<h2>{{ data['repository'] }}</h2>
-{% for type_name, type_ in data['data'].types.items() %}
-<!---->
-<p>{{ type_.title | markdown | safe }}</p>
-<!---->
+<style>
+  .audit-severity-high {
+    color: #d33;
+    font-weight: bold;
+  }
+  .audit-severity-critical {
+    color: #800;
+    font-weight: bold;
+  }
+  .audit-fixed-in,
+  .audit-upgradable,
+  .audit-patchable {
+    font-size: 0.9em;
+    opacity: 0.8;
+  }
+</style>
+{% for repo in repositories %}
+<h2>{{ repo['repository'] }}</h2>
+{% for type_ in repo['global_types'] %}
+<p>{{ type_['title'] | markdown | safe }}</p>
 {% endfor %}
 <!---->
-{% if data['data'].vulnerabilities %}
-<h3>Vulnerabilities</h3>
-{% for branch_name, files in data['data'].vulnerabilities.items() %}
-<h4>{{ branch_name }}</h4>
-{% for file_name, vulns in files.items() %}
+{% for branch in repo['branches'] %}
+<h3>{{ branch['name'] }}</h3>
+{% for type_ in branch['types'] %}
+<p>{{ type_['title'] | markdown | safe }}</p>
+{% endfor %}
+<!---->
+{% if branch['vulnerabilities'] %}
+<h4>Vulnerabilities</h4>
+{% for file_name, vulns in branch['vulnerabilities'].items() %}
 <h5>{{ file_name }}</h5>
 <ul>
   {% for vuln in vulns %}
-  <li>{{ vuln.title }}</li>
+  <li>{{ vuln.title | safe }}</li>
   {% endfor %}
 </ul>
 {% endfor %}
 <!---->
-{% endfor %}
-<!---->
 {% endif %}
+<!---->
+{% endfor %}
 <!---->
 {% endfor %}

--- a/github_app_geo_project/module/audit/utils.py
+++ b/github_app_geo_project/module/audit/utils.py
@@ -641,20 +641,24 @@ async def _snyk_test(
                 display = True
             if not display:
                 continue
+            severity = vuln["severity"]
+            severity_class = f' class="audit-severity-{severity}"'
             title = " ".join(
                 [
-                    f"[{vuln['severity'].upper()}]",
+                    f"<span{severity_class}>[{severity.upper()}]</span>",
                     f"{vuln['packageName']}@{vuln['version']}:",
-                    f"[{vuln['id']}](https://security.snyk.io/vuln/{vuln['id']})",
+                    f'<a href="https://security.snyk.io/vuln/{vuln["id"]}">{vuln["id"]}</a>',
                     *(vuln.get("identifiers", {}).get("CWE", [])),
                 ],
             )
             if vuln.get("fixedIn", []):
-                title += " [Fixed in: " + ", ".join(vuln["fixedIn"]) + "]."
+                title += (
+                    ' <span class="audit-fixed-in">[Fixed in: ' + ", ".join(vuln["fixedIn"]) + "]</span>."
+                )
             elif vuln.get("isUpgradable", False):
-                title += " [Upgradable]."
+                title += ' <span class="audit-upgradable">[Upgradable]</span>.'
             elif vuln.get("isPatchable", False):
-                title += " [Patch available]."
+                title += ' <span class="audit-patchable">[Patch available]</span>.'
             else:
                 title += "."
             if vuln.get("fixedIn", []) or vuln.get("isUpgradable", False) or vuln.get("isPatchable", False):


### PR DESCRIPTION
## Summary

Improve the audit transversal dashboard layout and vulnerability display.

## Changes

- **Group types by branch**: Types like "Dpkg master: Logs, Output, Pull request" are now displayed per-branch, at the top of each branch section, before vulnerabilities
- **Color severity badges**: `[HIGH]` and `[CRITICAL]` severity badges are now colored (red/bordeaux) using CSS classes
- **Always show Output link**: `_process_error` always creates an output and returns a URL, so the Output link is always present in the dashboard
- **HTML links for Snyk IDs**: Vulnerability titles now use HTML `<a>` tags directly instead of Markdown syntax, making the Snyk links clickable in the dashboard
- **Empty repository filtering**: Repositories with no types and no vulnerabilities are now filtered out from the dashboard
- **CSS classes**: Added `.audit-severity-high`, `.audit-severity-critical`, `.audit-fixed-in`, `.audit-upgradable`, `.audit-patchable` in the dashboard template

## Context

Previously, the dashboard showed all types and vulnerabilities at the repository level without branch grouping. The Output link was only shown on errors. Vulnerability severity badges were plain text, and Snyk links were not clickable because Markdown was not rendered.