### PR TITLE
Force author and publisher to None in RepositoryAdvisory paginator

### DIFF
--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -664,10 +664,7 @@ async def _create_pull_request_if_changes(
 
 
 def _add_missing_fields(item: dict[str, Any]) -> dict[str, Any]:
-    item = {**item}
-    item.setdefault("publisher", None)
-    item.setdefault("author", None)
-    return item
+    return {**item, "publisher": None, "author": None}
 
 
 async def _create_security_advisories(


### PR DESCRIPTION
## Summary

Fix the `_add_missing_fields` function to force `author` and `publisher` to `None` instead of using `setdefault`.

## Context

The GitHub API can return actual user objects for `author` and `publisher` fields in the `RepositoryAdvisory` response, but the Pydantic model expects these fields to be `None`. The previous `setdefault` approach only added the fields when they were completely missing from the dict, but did not handle the case where the API returns a dict value (e.g., `{'login': 'sbrunner', 'id': ...}`).

## Implementation Details

Changed `setdefault` to direct assignment so that any value returned by the API is overwritten with `None`, matching the Pydantic model definition.

## Impact/Risks

No risk — these fields are deprecated in favor of `credits_`/`credits_detailed` in the GitHub API.