### PR TITLE
Audit: deduplicate vulnerabilities and cleanup issue body

### DIFF
--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -413,6 +413,11 @@ async def _process_snyk_dpkg(
                             break
                     del issue_check.issue[found_start:section_end]
 
+                # Remove any remaining non-action items from the issue body
+                issue_check.issue = [
+                    item for item in issue_check.issue if isinstance(item, module_utils.DashboardIssueItem)
+                ]
+
                 # Apply filtering and build new dashboard section
                 snyk_config = context.module_config.get("snyk", {})
                 local_snyk_config = local_config.get("snyk", {})

--- a/github_app_geo_project/module/audit/utils.py
+++ b/github_app_geo_project/module/audit/utils.py
@@ -699,7 +699,12 @@ async def _snyk_test(
                 is_upgradable=vuln.get("isUpgradable", False),
                 is_patchable=vuln.get("isPatchable", False),
             )
-            file_vulnerabilities.setdefault(target_file, []).append(vuln_data)
+            existing_vulns = file_vulnerabilities.setdefault(target_file, [])
+            if not any(
+                v.snyk_id == vuln_data.snyk_id and v.package_version == vuln_data.package_version
+                for v in existing_vulns
+            ):
+                existing_vulns.append(vuln_data)
 
         for title, vulnerability in vulnerabilities.items():
             message = module_utils.HtmlMessage(

--- a/tests/test_module_audit.py
+++ b/tests/test_module_audit.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 
 from github_app_geo_project.module.audit import Audit, _EventData, _process_renovate
+from github_app_geo_project.module.audit.utils import VulnerabilityData
 
 
 @pytest.mark.asyncio
@@ -518,3 +519,138 @@ def test_get_excluded_files() -> None:
     local_config["excluded-files"] = [r"test-.*\.txt"]
     result = get_excluded_files(config, local_config)
     assert result == [r"test-.*\.txt"]
+
+
+def test_vulnerability_deduplication() -> None:
+    """Test that VulnerabilityData with same (snyk_id, package_version) for the same file is deduplicated."""
+    from github_app_geo_project.module.audit.utils import VulnerabilityData
+
+    vuln1 = VulnerabilityData(
+        file="pyproject.toml",
+        package_name="black",
+        package_version="24.3.0",
+        package_manager="pip",
+        severity="high",
+        snyk_id="SNYK-PYTHON-BLACK-15518063",
+        cve_ids=["CVE-2024-12345"],
+        cwe_ids=["CWE-22"],
+        title="[HIGH] black@24.3.0: [SNYK-PYTHON-BLACK-15518063]",
+        fixed_in=["26.3.1"],
+        is_upgradable=True,
+        is_patchable=False,
+    )
+    vuln2 = VulnerabilityData(
+        file="pyproject.toml",
+        package_name="black",
+        package_version="24.3.0",
+        package_manager="pip",
+        severity="high",
+        snyk_id="SNYK-PYTHON-BLACK-15518063",
+        cve_ids=["CVE-2024-12345"],
+        cwe_ids=["CWE-22"],
+        title="[HIGH] black@24.3.0: [SNYK-PYTHON-BLACK-15518063]",
+        fixed_in=["26.3.1"],
+        is_upgradable=True,
+        is_patchable=False,
+    )
+    vuln3 = VulnerabilityData(
+        file="pyproject.toml",
+        package_name="black",
+        package_version="24.3.0",
+        package_manager="pip",
+        severity="high",
+        snyk_id="SNYK-PYTHON-BLACK-15518063",
+        cve_ids=["CVE-2024-12345"],
+        cwe_ids=["CWE-22"],
+        title="[HIGH] black@24.3.0: [SNYK-PYTHON-BLACK-15518063]",
+        fixed_in=["26.3.1"],
+        is_upgradable=True,
+        is_patchable=False,
+    )
+
+    file_vulnerabilities: dict[str, list[VulnerabilityData]] = {}
+    for vuln in [vuln1, vuln2, vuln3]:
+        existing = file_vulnerabilities.setdefault(vuln.file, [])
+        if not any(
+            v.snyk_id == vuln.snyk_id and v.package_version == vuln.package_version
+            for v in existing
+        ):
+            existing.append(vuln)
+
+    assert len(file_vulnerabilities["pyproject.toml"]) == 1
+    assert file_vulnerabilities["pyproject.toml"][0].snyk_id == "SNYK-PYTHON-BLACK-15518063"
+
+
+def test_vulnerability_deduplication_different_versions() -> None:
+    """Test that different versions of the same vulnerability are not considered duplicates."""
+    from github_app_geo_project.module.audit.utils import VulnerabilityData
+
+    vuln1 = VulnerabilityData(
+        file="pyproject.toml",
+        package_name="black",
+        package_version="24.3.0",
+        package_manager="pip",
+        severity="high",
+        snyk_id="SNYK-PYTHON-BLACK-15518063",
+        cve_ids=["CVE-2024-12345"],
+        cwe_ids=["CWE-22"],
+        title="[HIGH] black@24.3.0: [SNYK-PYTHON-BLACK-15518063]",
+        fixed_in=["26.3.1"],
+        is_upgradable=True,
+        is_patchable=False,
+    )
+    vuln2 = VulnerabilityData(
+        file="pyproject.toml",
+        package_name="black",
+        package_version="26.3.1",
+        package_manager="pip",
+        severity="high",
+        snyk_id="SNYK-PYTHON-BLACK-15518063",
+        cve_ids=["CVE-2024-12345"],
+        cwe_ids=["CWE-22"],
+        title="[HIGH] black@26.3.1: [SNYK-PYTHON-BLACK-15518063]",
+        fixed_in=["26.3.1"],
+        is_upgradable=True,
+        is_patchable=False,
+    )
+
+    file_vulnerabilities: dict[str, list[VulnerabilityData]] = {}
+    for vuln in [vuln1, vuln2]:
+        existing = file_vulnerabilities.setdefault(vuln.file, [])
+        if not any(
+            v.snyk_id == vuln.snyk_id and v.package_version == vuln.package_version
+            for v in existing
+        ):
+            existing.append(vuln)
+
+    assert len(file_vulnerabilities["pyproject.toml"]) == 2
+
+
+def test_issue_body_cleanup() -> None:
+    """Test that non-action items are removed from the issue body."""
+    from github_app_geo_project.module import utils as module_utils
+
+    DashboardIssue = module_utils.DashboardIssue
+
+    issue = DashboardIssue(
+        "## Audit (Snyk/dpkg/Renovate)\n"
+        "\n"
+        '- [ ] <!-- outdated --> Check outdated version\n'
+        '- [ ] <!-- snyk --> Check security vulnerabilities with Snyk\n'
+        '- [ ] <!-- dpkg --> Update dpkg packages\n'
+        "\n"
+        "==== pyproject.toml\n"
+        "- [HIGH] black@24.3.0: ..\n"
+        "==== requirements.txt\n"
+        "- [HIGH] dulwich@0.21.7: ..\n"
+    )
+    issue.issue = [
+        item for item in issue.issue if isinstance(item, module_utils.DashboardIssueItem)
+    ]
+    result = issue.to_string()
+    assert "==== pyproject.toml" not in result
+    assert "==== requirements.txt" not in result
+    assert "[HIGH]" not in result
+    assert "Check outdated version" in result
+    assert "Check security vulnerabilities with Snyk" in result
+    assert "Update dpkg packages" in result

--- a/tests/test_module_audit.py
+++ b/tests/test_module_audit.py
@@ -435,7 +435,6 @@ def test_get_actions_push_security_md_on_non_default_branch_no_renovate() -> Non
 
 def test_vulnerability_data_structure() -> None:
     """Test VulnerabilityData creation."""
-    from github_app_geo_project.module.audit.utils import VulnerabilityData
 
     vuln = VulnerabilityData(
         file="requirements.txt",
@@ -523,7 +522,6 @@ def test_get_excluded_files() -> None:
 
 def test_vulnerability_deduplication() -> None:
     """Test that VulnerabilityData with same (snyk_id, package_version) for the same file is deduplicated."""
-    from github_app_geo_project.module.audit.utils import VulnerabilityData
 
     vuln1 = VulnerabilityData(
         file="pyproject.toml",
@@ -571,10 +569,7 @@ def test_vulnerability_deduplication() -> None:
     file_vulnerabilities: dict[str, list[VulnerabilityData]] = {}
     for vuln in [vuln1, vuln2, vuln3]:
         existing = file_vulnerabilities.setdefault(vuln.file, [])
-        if not any(
-            v.snyk_id == vuln.snyk_id and v.package_version == vuln.package_version
-            for v in existing
-        ):
+        if not any(v.snyk_id == vuln.snyk_id and v.package_version == vuln.package_version for v in existing):
             existing.append(vuln)
 
     assert len(file_vulnerabilities["pyproject.toml"]) == 1
@@ -583,7 +578,6 @@ def test_vulnerability_deduplication() -> None:
 
 def test_vulnerability_deduplication_different_versions() -> None:
     """Test that different versions of the same vulnerability are not considered duplicates."""
-    from github_app_geo_project.module.audit.utils import VulnerabilityData
 
     vuln1 = VulnerabilityData(
         file="pyproject.toml",
@@ -617,10 +611,7 @@ def test_vulnerability_deduplication_different_versions() -> None:
     file_vulnerabilities: dict[str, list[VulnerabilityData]] = {}
     for vuln in [vuln1, vuln2]:
         existing = file_vulnerabilities.setdefault(vuln.file, [])
-        if not any(
-            v.snyk_id == vuln.snyk_id and v.package_version == vuln.package_version
-            for v in existing
-        ):
+        if not any(v.snyk_id == vuln.snyk_id and v.package_version == vuln.package_version for v in existing):
             existing.append(vuln)
 
     assert len(file_vulnerabilities["pyproject.toml"]) == 2
@@ -635,18 +626,16 @@ def test_issue_body_cleanup() -> None:
     issue = DashboardIssue(
         "## Audit (Snyk/dpkg/Renovate)\n"
         "\n"
-        '- [ ] <!-- outdated --> Check outdated version\n'
-        '- [ ] <!-- snyk --> Check security vulnerabilities with Snyk\n'
-        '- [ ] <!-- dpkg --> Update dpkg packages\n'
+        "- [ ] <!-- outdated --> Check outdated version\n"
+        "- [ ] <!-- snyk --> Check security vulnerabilities with Snyk\n"
+        "- [ ] <!-- dpkg --> Update dpkg packages\n"
         "\n"
         "==== pyproject.toml\n"
         "- [HIGH] black@24.3.0: ..\n"
         "==== requirements.txt\n"
         "- [HIGH] dulwich@0.21.7: ..\n"
     )
-    issue.issue = [
-        item for item in issue.issue if isinstance(item, module_utils.DashboardIssueItem)
-    ]
+    issue.issue = [item for item in issue.issue if isinstance(item, module_utils.DashboardIssueItem)]
     result = issue.to_string()
     assert "==== pyproject.toml" not in result
     assert "==== requirements.txt" not in result


### PR DESCRIPTION
## Summary
Add deduplication of vulnerability data in the Snyk audit module and cleanup of stale CVE entries from the issue dashboard body.

## Implementation Details
- **Deduplicate vulnerabilities**: In `_snyk_test()`, before appending a `VulnerabilityData` to `file_vulnerabilities[target_file]`, check if an entry with the same `(snyk_id, package_version)` already exists for that file. This prevents duplicate entries in the web dashboard when Snyk reports the same vulnerability through multiple dependency paths.
- **Cleanup issue body**: After removing old `<!-- vulns-{branch} -->` sections, also remove all non-action strings from the `DashboardIssue.issue` list, keeping only the checkbox items. This ensures stale CVE entries (like file headers `==== ...` and vulnerability lines `- [HIGH] ...`) are removed from the issue dashboard.

## Impact/Risks
- Low risk. The deduplication is additive (only prevents duplicates, never removes valid entries). The issue body cleanup only removes non-action strings, which are not used by the current system.