### PR TITLE
Fix silent job failure logs

### DIFF
--- a/github_app_geo_project/scripts/process_queue.py
+++ b/github_app_geo_project/scripts/process_queue.py
@@ -255,6 +255,23 @@ async def _process_job(
             )
 
     if module_config.get("enabled", project_configuration.MODULE_ENABLED_DEFAULT):
+        root_logger.addHandler(handler)
+        old_level = root_logger.level
+        root_logger.setLevel(logging.DEBUG)
+        log_task = None
+        log_session_factory = sqlalchemy.ext.asyncio.async_sessionmaker(
+            bind=session.bind,
+        )
+        log_interval = settings.process_queue.logs_stream_interval.total_seconds()
+        log_task = asyncio.create_task(
+            _stream_job_logs(
+                log_session_factory,
+                handler,
+                job.id,
+                log_interval,
+            ),
+            name=f"Stream logs {job.id}",
+        )
         try:
             if not settings.test.app_name:
                 if job.check_run_id is None and job.owner is not None and job.repository is not None:
@@ -298,23 +315,6 @@ async def _process_job(
                 issue_data=issue_data,
                 job_id=job.id,
                 service_url=settings.service_url,
-            )
-            root_logger.addHandler(handler)
-            old_level = root_logger.level
-            root_logger.setLevel(logging.DEBUG)
-            log_task = None
-            log_interval = settings.process_queue.logs_stream_interval.total_seconds()
-            log_session_factory = sqlalchemy.ext.asyncio.async_sessionmaker(
-                bind=session.bind,
-            )
-            log_task = asyncio.create_task(
-                _stream_job_logs(
-                    log_session_factory,
-                    handler,
-                    job.id,
-                    log_interval,
-                ),
-                name=f"Stream logs {job.id}",
             )
             result = None
             try:
@@ -685,6 +685,14 @@ async def _process_job(
                         github_exception.response.status_code,
                     )
             raise
+        finally:
+            root_logger.setLevel(old_level)
+            root_logger.removeHandler(handler)
+            if log_task is not None:
+                log_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await log_task
+            await _flush_job_logs(log_session_factory, handler, job.id)
     else:
         try:
             _LOGGER.info("Module %s is disabled", job.module)
@@ -1114,6 +1122,10 @@ async def _process_one_job(
         job.log = None
     finally:
         sentry_sdk.set_context("job", {})
+        log_session_factory = sqlalchemy.ext.asyncio.async_sessionmaker(
+            bind=session.bind,
+        )
+        await _flush_job_logs(log_session_factory, handler, job.id)
         if await session.run_sync(lambda _: job.status_enum == models.JobStatus.PENDING):
             _LOGGER.error("Job %s finished with pending status", job.id)
             job.status_enum = models.JobStatus.ERROR


### PR DESCRIPTION
## Summary

Fix an issue where jobs can fail with status `ERROR` but have no log entries in the database, making it impossible to diagnose the root cause.

## Root Cause

The `_Handler` that captures logs for database storage was attached to `root_logger` too late in `_process_job()` (after the GitHub API setup phase). If an exception occurred during setup (`create_checks`, rate limit checks, config loading, etc.), the logging handler was never attached, so `_LOGGER.exception()` calls went to Sentry/console but not to the job's log buffer. The job then finished with `ERROR` status and empty logs.

## Changes

1. **Handler attached earlier**: Moved `root_logger.addHandler(handler)` and `log_task` creation to the beginning of the enabled module block, before any setup code runs.

2. **Outer `finally` for cleanup**: Added a `finally` block to the outer `try` in `_process_job()` that systematically cleans up the handler, cancels the log streaming task, and flushes logs to the database.

3. **Safety net flush**: Added `_flush_job_logs()` in `_process_one_job()`'s `finally` block to ensure the start message and any captured logs are persisted even if `_process_job()` fails before its own flush.

## Impact

- Jobs that fail during the setup phase will now have their error messages captured in the database logs instead of being silently lost.
- No behavior change for successful jobs.
- The double cleanup (inner finally + outer finally) is safe — `removeHandler`, `cancel`, and `_flush_job_logs` are all idempotent.