### PR TITLE
Fix patch module: capture stderr and widen lock in working_tree

### DIFF
--- a/github_app_geo_project/module/patch/__init__.py
+++ b/github_app_geo_project/module/patch/__init__.py
@@ -289,6 +289,7 @@ class Patch(module.Module[dict[str, Any], dict[str, Any], dict[str, Any], Any]):
                         *command,
                         stdin=asyncio.subprocess.PIPE,
                         stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
                         cwd=cwd,
                     )
                     async with asyncio.timeout(60):
@@ -327,6 +328,7 @@ class Patch(module.Module[dict[str, Any], dict[str, Any], dict[str, Any], Any]):
                         *command,
                         stdin=asyncio.subprocess.PIPE,
                         stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
                         cwd=cwd,
                     )
                     async with asyncio.timeout(60):

--- a/github_app_geo_project/module/utils.py
+++ b/github_app_geo_project/module/utils.py
@@ -1198,8 +1198,7 @@ class GitWorktreeCache:
         async with lock:
             cache_path = await self._ensure_cache(github_project)
 
-        worktree_path = Path(tempfile.mkdtemp())
-        try:
+            worktree_path = Path(tempfile.mkdtemp())
             # Create/update local branch to match remote (ensures the branch exists locally)
             _, success, _ = await run_timeout(
                 ["git", "branch", "-f", branch, f"origin/{branch}"],
@@ -1228,21 +1227,23 @@ class GitWorktreeCache:
                 message = f"Failed to add worktree for branch {branch}"
                 raise module.GHCIError(message)
 
+        try:
             yield worktree_path
         finally:
-            # Remove worktree
-            await run_timeout(
-                ["git", "worktree", "remove", "--force", str(worktree_path)],
-                None,
-                60,
-                f"Remove worktree for {branch}",
-                f"Error removing worktree for {branch}",
-                f"Timeout removing worktree for {branch}",
-                cache_path,
-                error=False,
-            )
-            # Ensure cleanup of any leftover files
-            shutil.rmtree(worktree_path, ignore_errors=True)
+            async with lock:
+                # Remove worktree
+                await run_timeout(
+                    ["git", "worktree", "remove", "--force", str(worktree_path)],
+                    None,
+                    60,
+                    f"Remove worktree for {branch}",
+                    f"Error removing worktree for {branch}",
+                    f"Timeout removing worktree for {branch}",
+                    cache_path,
+                    error=False,
+                )
+                # Ensure cleanup of any leftover files
+                shutil.rmtree(worktree_path, ignore_errors=True)
 
 
 GIT_WORKTREE_CACHE = GitWorktreeCache()


### PR DESCRIPTION
## Summary

Fix two issues introduced in the git worktree cache refactoring (PR #1370):

1. The `git apply` and `git push` subprocess calls in the patch module were missing `stderr=asyncio.subprocess.PIPE`, so error output from failed patch applications was silently discarded.

2. The per-repository lock in `GitWorktreeCache.working_tree()` only covered `_ensure_cache`, leaving the `git branch -f` and `git worktree add` operations unprotected against concurrent access.

## Implementation Details

### stderr capture (`patch/__init__.py`)

Added `stderr=asyncio.subprocess.PIPE` to both `git apply` and `git push` subprocess calls, matching the pattern used elsewhere in the codebase (e.g. `run_timeout()`).

### Widened lock (`utils.py`)

Moved `git branch -f`, `git worktree add`, and `git worktree remove` inside the per-repository lock. The lock now covers:
- Setup: `_ensure_cache` + branch update + worktree creation
- The `yield` remains outside the lock (caller work is not blocked)
- Cleanup: re-acquires the lock for worktree removal

## Context

Closes investigation from job #2471598 where `git apply` was returning exit code 1 without any logged error output, making debugging impossible.