### PR TITLE
Fix GitWorktreeCache: update remote URL with fresh token before fetch

### DIFF
--- a/github_app_geo_project/module/utils.py
+++ b/github_app_geo_project/module/utils.py
@@ -1132,6 +1132,22 @@ class GitWorktreeCache:
                     await file.write(github_project.application.private_key)
 
         if await anyio.Path(cache_path / ".git").exists():
+            # Update the remote URL with the current token in case it has expired
+            await run_timeout(
+                [
+                    "git",
+                    "remote",
+                    "set-url",
+                    "origin",
+                    f"https://x-access-token:{github_project.token}@github.com/{github_project.owner}/{github_project.repository}.git",
+                ],
+                None,
+                60,
+                "Update remote URL",
+                "Error updating remote URL",
+                "Timeout updating remote URL",
+                cache_path,
+            )
             # Fetch latest updates
             _, success, _ = await run_timeout(
                 ["git", "fetch", "--prune", "origin"],


### PR DESCRIPTION
## Summary

Fix the `GitWorktreeCache` to update the remote URL with the current token before each fetch operation.

## Context

Since PR #1370 refactored git operations to use a cached worktree approach, the cached repository's remote URL contains the token from the initial clone. GitHub App installation tokens are short-lived (typically 1 hour), so when the cache is reused, the stored token is expired and git operations fail with:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
```

## Implementation Details

In `_ensure_cache()`, before running `git fetch --prune origin`, added a `git remote set-url origin` command that updates the remote URL with the current token. This ensures the cached repository always has a valid token for authentication.

## Impact/Risks

- Low risk: the change only adds a `git remote set-url` command before the existing fetch operation
- No new dependencies or configuration changes needed
- All 167 existing tests pass