### PR TITLE
Fix git worktree conflict when branch is already used by another worktree

### DIFF
--- a/github_app_geo_project/module/utils.py
+++ b/github_app_geo_project/module/utils.py
@@ -1238,23 +1238,9 @@ class GitWorktreeCache:
             cache_path = await self._ensure_cache(github_project)
 
             worktree_path = Path(tempfile.mkdtemp())
-            # Create/update local branch to match remote (ensures the branch exists locally)
+            # Create worktree in detached HEAD to avoid conflicts with other worktrees
             _, success, _ = await run_timeout(
-                ["git", "branch", "-f", branch, f"origin/{branch}"],
-                None,
-                120,
-                f"Update branch {branch}",
-                f"Error updating branch {branch}",
-                f"Timeout updating branch {branch}",
-                cache_path,
-            )
-            if not success:
-                message = f"Failed to update branch {branch}"
-                raise module.GHCIError(message)
-
-            # Create worktree
-            _, success, _ = await run_timeout(
-                ["git", "worktree", "add", str(worktree_path), branch],
+                ["git", "worktree", "add", "--detach", str(worktree_path), f"origin/{branch}"],
                 None,
                 120,
                 f"Add worktree for {branch}",


### PR DESCRIPTION
## Summary

Use `git worktree add --detach` with `origin/<branch>` instead of creating a local branch with `git branch -f`, which fails when the branch is already checked out in another worktree.

## Context

When a branch (e.g. `master`) is already checked out in another worktree, `git branch -f master origin/master` fails with:

```
fatal: cannot force update the branch 'master' used by worktree at '/var/www/.cache/ghci/git/sbrunner/docker-vim'
```

This causes the audit module to fail with a `GHCIError`.

## Implementation Details

- Removed the `git branch -f` step that created/updated a local branch before adding the worktree
- Changed `git worktree add` to use `--detach` with the remote tracking branch reference (`origin/<branch>`)
- The worktree is now in detached HEAD state, which is safe because all callers either read files or create new branches with `git checkout -b` before committing

## Impact/Risks

- Low risk: all existing callers work with detached HEAD since they create their own branches
- Fixes the audit module failure when the default branch is used by another worktree