### PR TITLE
Fix audit module: remove old vuln format, stop markdown in summary, fix output creation

### DIFF
--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -129,7 +129,7 @@ async def _process_error(
     output_renderer_data: dict[str, Any] | None = None,
 ) -> _TransversalStatusTool:
     logs_url = urllib.parse.urljoin(context.service_url, f"logs/{context.job_id}")
-    output_url = ""
+    output_url: str | None = None
     if error_message:
         if output_name:
             await module_utils.add_output(
@@ -148,15 +148,20 @@ async def _process_error(
         issue_check.set_title(
             key,
             (
-                f"{key}: {message} ([Logs]({logs_url}) [Output]({output_url}))"
+                f"{key}: {message} ([Logs]({logs_url}){f' [Output]({output_url})' if output_url else ''})"
                 if message
-                else f"{key} ([Logs]({logs_url}) [Output]({output_url}))"
+                else f"{key} ([Logs]({logs_url}){f', [Output]({output_url})' if output_url else ''})"
             ),
         )
     elif message:
-        issue_check.set_title(key, f"{key}: {message} ([Logs]({logs_url}), [Output]({output_url}))")
+        issue_check.set_title(
+            key, f"{key}: {message} ([Logs]({logs_url}){f', [Output]({output_url})' if output_url else ''})"
+        )
     else:
-        issue_check.set_title(key, f"{key}: everything is fine ([Logs]({logs_url}), [Output]({output_url}))")
+        issue_check.set_title(
+            key,
+            f"{key}: everything is fine ([Logs]({logs_url}){f', [Output]({output_url})' if output_url else ''})",
+        )
 
     return _TransversalStatusTool(
         name=key,
@@ -425,14 +430,6 @@ async def _process_snyk_dpkg(
                 )
                 message.title = "Output URL"
                 _LOGGER.debug(message)
-                if output_tool.output_url is not None:
-                    short_message.append(f"[Output]({output_tool.output_url})")
-                    if body_md:
-                        body_md += "\n\n"
-                    body_md += (
-                        f"[Output]({output_tool.output_url})" if output_tool.output_url is not None else ""
-                    )
-
                 # Remove old vulnerability section (both old comment format and new format)
                 vuln_section_start = f"<!-- vulns-{branch} -->"
                 vuln_section_end = f"<!-- /vulns-{branch} -->"
@@ -456,6 +453,21 @@ async def _process_snyk_dpkg(
                             section_end = j
                             break
                     del issue_check.issue[found_start:section_end]
+                else:
+                    # Old format: remove ==== file sections (no === branch wrapper)
+                    start = None
+                    end = None
+                    for i, item in enumerate(issue_check.issue):
+                        if start is None and isinstance(item, str) and item.startswith("===="):
+                            start = i
+                        if start is not None and isinstance(item, str) and item == "<!---->":
+                            end = i
+                            break
+                    if start is not None:
+                        if end is not None:
+                            del issue_check.issue[start:end]
+                        else:
+                            del issue_check.issue[start:]
 
                 # Apply filtering and build new dashboard section
                 snyk_config = context.module_config.get("snyk", {})
@@ -576,6 +588,22 @@ async def _process_snyk_dpkg(
                 if high_critical_vulns:
                     await _create_security_advisories(context, high_critical_vulns)
 
+                # Create output for vulnerabilities
+                if output_name:
+                    await module_utils.add_output(
+                        context,
+                        key,
+                        output_name,
+                        "github_app_geo_project:module/audit/output.html",
+                        status=models.OutputStatus.SUCCESS,
+                        renderer_data=output_renderer_data,
+                    )
+                    output_url = urllib.parse.urljoin(
+                        context.service_url,
+                        f"output/{context.github_project.owner}/{context.github_project.repository}/{output_name}",
+                    )
+                    output_tool.output_url = output_url
+
             if context.module_event_data.type == "dpkg":
                 body_md = "Update dpkg packages"
 
@@ -590,7 +618,6 @@ async def _process_snyk_dpkg(
 
             body_md += "\n" if body_md else ""
             body_md += f"[Logs]({logs_url})"
-            short_message.append(f"[Logs]({logs_url})")
 
             new_success, pr_messages = await _create_pull_request_if_changes(
                 branch,


### PR DESCRIPTION
# Summary

Fix three issues in the audit module:

1. **Remove old vulnerability format from dashboard issue**: The old `==== file` format vulnerability sections were not being removed from the GitHub issue body, leaving stale CVE lists. Added handling for this format.

2. **Stop markdown links in dashboard summary**: The `summary` field in the transversal status contained markdown links like `[Logs](url)` which were rendered as raw text in the dashboard template. The template already has separate `<a>` tags for Logs and Output links.

3. **Fix output creation**: The `add_output` call was happening inside `_process_error` before `output_name` was determined (was always `None`). Moved it after the vulnerability filtering so outputs are actually created.

## Context

- Related to issues found on mapfish/mapfish-print dashboard
- JIRA/TODO: PLAT-3293

<!-- pull request links -->
See JIRA issue: [PLAT-3293](https://camptocamp.atlassian.net/browse/PLAT-3293).