### PR TITLE
Fix output route template resolution for module templates

### DIFF
--- a/github_app_geo_project/app.py
+++ b/github_app_geo_project/app.py
@@ -31,6 +31,7 @@ from github_app_geo_project.templates import (
     pprint_duration,
     pprint_full_date,
     pprint_short_date,
+    render_template,
     sanitizer,
 )
 from github_app_geo_project.views.dashboard import DashboardData
@@ -256,18 +257,15 @@ async def schema_route(data: SchemaData) -> dict[str, Any]:
 
 
 @app.get(f"{route_prefix}output/{{owner}}/{{repository}}/{{name}}")
-async def output_route(request: Request, data: OutputByNameData) -> HTMLResponse:
+async def output_route(data: OutputByNameData) -> HTMLResponse:
     """Render the output page by owner/repository/name."""
     renderer = data.pop("renderer", None)
     renderer_data = data.pop("renderer_data", None)
-    template_kwargs = {**data}
+    template_kwargs: dict[str, Any] = {**data}
     if renderer_data:
         template_kwargs["renderer_data"] = renderer_data
-    return templates.TemplateResponse(
-        request,
-        renderer,
-        template_kwargs,
-    )
+    html = await render_template(renderer, template_kwargs)
+    return HTMLResponse(html)
 
 
 @app.get(f"{route_prefix}logs/{{logs_id}}")

--- a/github_app_geo_project/templates/__init__.py
+++ b/github_app_geo_project/templates/__init__.py
@@ -2,8 +2,11 @@
 
 import datetime
 import logging
+from typing import Any
 
+import anyio
 import markdown as markdown_lib
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from markupsafe import Markup
 
 from github_app_geo_project.module.utils import _SANITIZER
@@ -85,3 +88,22 @@ def pprint_duration(duration: datetime.timedelta | None) -> str:
         return f"{round(duration.total_seconds() / 3600)} hour{plural}"
     plural = "" if round(seconds_abs / 86400) == 1 else "s"
     return f"{round(duration.total_seconds() / 86400)} day{plural}"
+
+
+async def render_template(renderer: str, data: dict[str, Any]) -> str:
+    """Render a template from a renderer string in the format 'package:path'."""
+    package, path = renderer.split(":", 1)
+    package_dir = anyio.Path(__file__).parent.parent.parent / package
+    template_path = package_dir / path
+    env = Environment(
+        loader=FileSystemLoader(str(template_path.parent)),
+        autoescape=select_autoescape(),
+    )
+    env.filters["markdown"] = markdown
+    env.filters["sanitizer"] = sanitizer
+    env.filters["pprint_date"] = pprint_date
+    env.filters["pprint_short_date"] = pprint_short_date
+    env.filters["pprint_full_date"] = pprint_full_date
+    env.filters["pprint_duration"] = pprint_duration
+    template = env.get_template(template_path.name)
+    return template.render(data)

--- a/github_app_geo_project/views/dashboard.py
+++ b/github_app_geo_project/views/dashboard.py
@@ -3,43 +3,16 @@
 import logging
 from typing import Annotated, Any
 
-import anyio
 import sqlalchemy
 from fastapi import Depends, HTTPException, Request
-from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from github_app_geo_project import models, module
 from github_app_geo_project.module import modules
 from github_app_geo_project.security import User, get_user
-from github_app_geo_project.templates import (
-    markdown,
-    pprint_date,
-    pprint_duration,
-    pprint_full_date,
-    pprint_short_date,
-    sanitizer,
-)
+from github_app_geo_project.templates import render_template
 from github_app_geo_project.utils import HTML_FORMATTER
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def _render_template(renderer: str, data: dict[str, Any]) -> str:
-    package, path = renderer.split(":", 1)
-    package_dir = anyio.Path(__file__).parent.parent.parent / package
-    template_path = package_dir / path
-    env = Environment(
-        loader=FileSystemLoader(str(template_path.parent)),
-        autoescape=select_autoescape(),
-    )
-    env.filters["markdown"] = markdown
-    env.filters["sanitizer"] = sanitizer
-    env.filters["pprint_date"] = pprint_date
-    env.filters["pprint_short_date"] = pprint_short_date
-    env.filters["pprint_full_date"] = pprint_full_date
-    env.filters["pprint_duration"] = pprint_duration
-    template = env.get_template(template_path.name)
-    return template.render(data)
 
 
 async def dashboard(
@@ -81,7 +54,7 @@ async def dashboard(
         data.setdefault("styles", HTML_FORMATTER.get_style_defs())
 
         if output.renderer:
-            data["html"] = await _render_template(output.renderer, data)
+            data["html"] = await render_template(output.renderer, data)
 
     return {
         "request": request,


### PR DESCRIPTION
## Summary

The `output_route` endpoint was using `Jinja2Templates.TemplateResponse()` (Starlette) which only resolves templates from the configured `template_dir`, while the renderer strings stored in the database use a `package:path` format (e.g. `github_app_geo_project:module/audit/output.html`).

## Context

The `dashboard_route` already handled this correctly via a custom `_render_template` function in `views/dashboard.py`, but the `output_route` in `app.py` passed the renderer string directly to `TemplateResponse`, causing a `jinja2.exceptions.TemplateNotFound` error.

## Implementation Details

- Extracted the private `_render_template` from `views/dashboard.py` into a public `render_template` function in `github_app_geo_project/templates/__init__.py` (where the template filter functions already live)
- Updated `views/dashboard.py` to import and use the shared function
- Updated `app.py:output_route` to use `render_template()` and return `HTMLResponse` instead of `TemplateResponse`

## Impact/Risks

No changes to modules, database schema, or stored renderer strings. The `package:path` format continues to work as before.