### PR TITLE
Fix audit renderer data serialization and add typed output model

### DIFF
--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -71,6 +71,15 @@ class _VulnerabilityStatus(BaseModel):
     """The reason the vulnerability is ignored (from .snyk file)."""
 
 
+class _OutputRendererData(BaseModel):
+    """Output renderer data for the audit module stored in the output."""
+
+    branch: str
+    vulnerabilities: dict[str, list[_VulnerabilityStatus]]
+    ignored_vulnerabilities: dict[str, list[_VulnerabilityStatus]]
+    low_severity_vulnerabilities: dict[str, list[_VulnerabilityStatus]]
+
+
 class _TransversalStatusRepo(BaseModel):
     types: dict[str, _TransversalStatusTool] = {}
 
@@ -126,7 +135,7 @@ async def _process_error(
     error_message: list[str | models.OutputData] | None = None,
     message: str | None = None,
     output_name: str | None = None,
-    output_renderer_data: dict[str, Any] | None = None,
+    output_renderer_data: _OutputRendererData | None = None,
 ) -> _TransversalStatusTool:
     logs_url = urllib.parse.urljoin(context.service_url, f"logs/{context.job_id}")
     output_url: str | None = None
@@ -415,7 +424,7 @@ async def _process_snyk_dpkg(
                 del body
                 success &= new_success
                 output_name: str = f"Snyk ${branch}"
-                output_renderer_data: dict[str, Any] | None = None
+                output_renderer_data: _OutputRendererData | None = None
                 output_tool = await _process_error(
                     context,
                     key,
@@ -565,12 +574,12 @@ async def _process_snyk_dpkg(
                         if low_severity_vulns
                         else {}
                     )
-                    output_renderer_data = {
-                        "branch": branch,
-                        "vulnerabilities": vuln_data,
-                        "ignored_vulnerabilities": ignored_data,
-                        "low_severity_vulnerabilities": low_severity_data,
-                    }
+                    output_renderer_data = _OutputRendererData(
+                        branch=branch,
+                        vulnerabilities=vuln_data,
+                        ignored_vulnerabilities=ignored_data,
+                        low_severity_vulnerabilities=low_severity_data,
+                    )
 
                 # Create security advisories for HIGH and CRITICAL CVEs
                 if high_critical_vulns:

--- a/github_app_geo_project/module/utils.py
+++ b/github_app_geo_project/module/utils.py
@@ -25,6 +25,7 @@ import security_md
 import sqlalchemy.ext.asyncio
 from ansi2html import Ansi2HTMLConverter
 from ansi2html.style import get_styles
+from pydantic import BaseModel
 
 from github_app_geo_project import configuration, models, module, utils
 
@@ -64,6 +65,17 @@ _SANITIZER_SETTINGS: dict[str, Any] = {
 _SANITIZER = html_sanitizer.Sanitizer(_SANITIZER_SETTINGS)
 
 
+def _serialize_renderer_data(data: Any) -> Any:
+    """Recursively convert Pydantic BaseModel instances to dicts for JSON serialization."""
+    if isinstance(data, BaseModel):
+        return data.model_dump()
+    if isinstance(data, dict):
+        return {key: _serialize_renderer_data(value) for key, value in data.items()}
+    if isinstance(data, list):
+        return [_serialize_renderer_data(item) for item in data]
+    return data
+
+
 async def add_output(
     context: module.ProcessContext[Any, Any],
     title: str,
@@ -71,7 +83,7 @@ async def add_output(
     renderer: str,
     status: models.OutputStatus = models.OutputStatus.SUCCESS,
     access_type: models.AccessType = models.AccessType.PULL,
-    renderer_data: dict[str, Any] | None = None,
+    renderer_data: dict[str, Any] | BaseModel | None = None,
 ) -> None:
     """Add or update an output in the database."""
     owner = context.github_project.owner if context.github_project else "camptocamp"
@@ -90,7 +102,7 @@ async def add_output(
         existing.status = status
         existing.access_type = access_type
         existing.renderer = renderer
-        existing.renderer_data = renderer_data
+        existing.renderer_data = _serialize_renderer_data(renderer_data)
         await context.session.commit()
         await context.session.refresh(existing)
         return


### PR DESCRIPTION
## Summary

Fix a crash where Pydantic `BaseModel` instances in `renderer_data` caused a `TypeError: Object of type _VulnerabilityStatus is not JSON serializable` when SQLAlchemy tried to serialize the data to the PostgreSQL JSON column.

## Context

The `renderer_data` dict contained `_VulnerabilityStatus` (Pydantic `BaseModel`) objects, which are not natively JSON-serializable. SQLAlchemy's JSON column uses `json.dumps()` internally, which failed on these objects.

## Implementation Details

- Added `_serialize_renderer_data` utility in `module/utils.py` that recursively converts any `BaseModel` instance to a plain dict via `.model_dump()` before storing in the database.
- Added a typed `_OutputRendererData` Pydantic model in `module/audit/__init__.py` to properly type the `renderer_data` structure.
- Changed `_process_error` and the success path to use `_OutputRendererData` instead of plain `dict[str, Any]`.