### PR TITLE
Cleanup old workflows older than 30 days from the dashboard

### DIFF
--- a/github_app_geo_project/module/workflow/__init__.py
+++ b/github_app_geo_project/module/workflow/__init__.py
@@ -1,6 +1,7 @@
 """Module to display the status of the workflows in the transversal dashboard."""
 
 import base64
+import datetime
 import logging
 from typing import Any
 
@@ -80,6 +81,42 @@ class Workflow(module.Module[None, dict[str, Any], dict[str, Any], None]):
         full_repo = f"{context.github_project.owner}/{context.github_project.repository}"
 
         module_utils.manage_updated(transversal_status, full_repo, days_old=30)
+
+        cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=30)
+        for repo_key, repo_data_cleanup in list(transversal_status.items()):
+            if not isinstance(repo_data_cleanup, dict):
+                continue
+            for branch_key, branch_data in list(repo_data_cleanup.items()):
+                if branch_key == "updated":
+                    continue
+                if not isinstance(branch_data, dict):
+                    continue
+                for workflow_key, workflow_data in list(branch_data.items()):
+                    if not isinstance(workflow_data, dict):
+                        del branch_data[workflow_key]
+                        continue
+                    workflow_date = workflow_data.get("date")
+                    if workflow_date:
+                        try:
+                            parsed_date = utils.datetime_with_timezone(
+                                datetime.datetime.fromisoformat(workflow_date)
+                            )
+                            if parsed_date < cutoff:
+                                del branch_data[workflow_key]
+                                _LOGGER.debug(
+                                    "Remove old workflow %s from %s/%s",
+                                    workflow_key,
+                                    repo_key,
+                                    branch_key,
+                                )
+                        except (ValueError, TypeError):
+                            del branch_data[workflow_key]
+                    else:
+                        del branch_data[workflow_key]
+                if not branch_data:
+                    del repo_data_cleanup[branch_key]
+            if repo_key != full_repo and (not repo_data_cleanup or repo_data_cleanup.keys() == {"updated"}):
+                del transversal_status[repo_key]
 
         repo_data = transversal_status[full_repo]
 

--- a/tests/test_module_workflow.py
+++ b/tests/test_module_workflow.py
@@ -294,3 +294,77 @@ async def test_process_failure() -> None:
             },
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_process_cleanup_old_workflows() -> None:
+    context = MagicMock()
+    context.github_project.owner = "owner"
+    context.github_project.repository = "repository"
+    context.github_event_name = "workflow_run"
+    context.module_event_name = "workflow_run"
+    context.github_event_data = dict(_EVENT)
+    context.github_event_data["workflow_run"]["conclusion"] = "failure"
+
+    default_branch = AsyncMock()
+    default_branch.return_value = "master"
+    context.github_project.default_branch = default_branch
+
+    repo = MagicMock()
+    context.github_project.aio_repo = repo
+    repo.default_branch = "master"
+    github = MagicMock()
+    context.github_project.aio_github = github
+    rest = MagicMock()
+    github.rest = rest
+    repos = AsyncMock()
+    rest.repos = repos
+    repo_response = MagicMock()
+    repo_response.status_code = 404
+    repos.async_get_content.side_effect = githubkit.exception.RequestFailed(repo_response)
+    actions = AsyncMock()
+    rest.actions = actions
+    actions_response = MagicMock()
+    actions_response.status_code = 200
+    actions_response.parsed_data = {
+        "total_count": 0,
+        "jobs": [],
+    }
+    actions.async_list_jobs_for_workflow_run.return_value = actions_response
+
+    workflow = Workflow()
+
+    transversal_status = await workflow.update_transversal_status(
+        context,
+        None,
+        {
+            "owner/repository": {
+                "old_workflow": {
+                    "date": "2020-01-01T00:00:00+00:00",
+                    "jobs": [],
+                    "url": "https://example.com/old",
+                },
+            },
+            "other/repo": {
+                "old_other_workflow": {
+                    "date": "2020-06-15T00:00:00+00:00",
+                    "jobs": [],
+                    "url": "https://example.com/old-other",
+                },
+            },
+        },
+    )
+
+    assert "updated" in transversal_status["owner/repository"]
+    del transversal_status["owner/repository"]["updated"]
+    assert transversal_status == {
+        "owner/repository": {
+            "master": {
+                "workflow_name": {
+                    "date": "2024-01-01T00:00:00+00:00",
+                    "jobs": [],
+                    "url": "https://github.com/user/repo/actions/runs/123456789",
+                },
+            },
+        },
+    }


### PR DESCRIPTION
## Summary

Remove workflows older than 30 days from the workflow dashboard to keep the display clean and relevant.

## Context

The dashboard was showing stale workflow runs that were never removed even after weeks or months. Only successful workflows were removed when a new event arrived. Old failed workflows remained indefinitely.

## Implementation Details

- Added a cleanup step in `update_transversal_status()` that runs before processing each workflow run event
- Iterates through all repos, branches, and workflows in the transversal status
- Removes workflow entries whose `date` field (workflow run creation date) is older than 30 days
- Cleans up empty branches and repos after removal
- The current repo being processed is preserved even if it would become empty (it is still being updated by the current event)
- The 30-day threshold is consistent with the existing `manage_updated()` call used for repo-level cleanup

## Impact/Risks

- Low risk: the cleanup only removes data that is more than 30 days old
- The cleanup runs on every `workflow_run` event, so old data is removed promptly