### PR TITLE
Reorder output page layout: title first, then status, then content

### DIFF
--- a/github_app_geo_project/module/audit/output.html
+++ b/github_app_geo_project/module/audit/output.html
@@ -20,7 +20,7 @@
     opacity: 0.8;
   }
 </style>
-<h1>{{ title }}</h1>
+
 {% if renderer_data %}
 <h2>{{ renderer_data['branch'] }}</h2>
 {% if renderer_data['vulnerabilities'] %}

--- a/github_app_geo_project/templates/output.html
+++ b/github_app_geo_project/templates/output.html
@@ -3,13 +3,13 @@
 {% block head_title %}{{ title }}{% endblock %}
 <!---->
 {% block content %}
+<h1>{{ title }}</h1>
 <p class="text-muted">
-  Status: {% if status == "success" %}<span class="text-success">Success</span>{% else %}<span
+  [{% if status == "success" %}<span class="text-success">Success</span>{% else %}<span
     class="text-danger"
     >Error</span
-  >{% endif %} | Last updated: {{ updated_at.strftime('%Y-%m-%d %H:%M:%S %Z') }}
+  >{% endif %}], Last updated: {{ updated_at.strftime('%Y-%m-%d %H:%M:%S %Z') }}, <a href="{{ url_for('project_route', owner=owner, repository=repository) }}">project</a>.
 </p>
-<p><a href="{{ url_for('project_route', owner=owner, repository=repository) }}">related project</a>.</p>
 
 {{ html | safe }}
 <!---->

--- a/github_app_geo_project/templates/output.html
+++ b/github_app_geo_project/templates/output.html
@@ -5,10 +5,10 @@
 {% block content %}
 <h1>{{ title }}</h1>
 <p class="text-muted">
-  [{% if status == "success" %}<span class="text-success">Success</span>{% else %}<span
-    class="text-danger"
+  [{% if status == "success" %}<span class="text-success">Success</span>{% else %}<span class="text-danger"
     >Error</span
-  >{% endif %}], Last updated: {{ updated_at.strftime('%Y-%m-%d %H:%M:%S %Z') }}, <a href="{{ url_for('project_route', owner=owner, repository=repository) }}">project</a>.
+  >{% endif %}], Last updated: {{ updated_at.strftime('%Y-%m-%d %H:%M:%S %Z') }},
+  <a href="{{ url_for('project_route', owner=owner, repository=repository) }}">project</a>.
 </p>
 
 {{ html | safe }}


### PR DESCRIPTION
## Summary

Reorder the output page so the title appears first, followed by the status line, then the inner content.

## Changes

- Move `<h1>` title from the module audit template to the outer `output.html` template
- Reformat status line: `Status: Success | Last updated: ...` → `[Success], Last updated: ...`
- Change link text: `related project` → `project`
- Combine the status and project link into a single paragraph