### PR TITLE
Report error instead of failing when push fails in patch module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-08-10
+
+### Changed
+
+- **Patch module**: When `git push` fails, the module now returns `ProcessOutput(success=False)` instead of raising `PatchError`. This marks the job as `REPORT_ERROR` (yellow warning) instead of `FAIL` (red danger), distinguishing a push failure from a system error.
+
 ## 2026-07-20
 
 ### Added

--- a/github_app_geo_project/module/patch/__init__.py
+++ b/github_app_geo_project/module/patch/__init__.py
@@ -340,8 +340,10 @@ class Patch(module.Module[dict[str, Any], dict[str, Any], dict[str, Any], Any]):
                     if proc.returncode != 0:
                         message.title = "Failed to push the changes"
                         _LOGGER.warning(message)
-                        error_message = f"Failed to push the changes{format_process_bytes(stdout, stderr)}"
-                        raise PatchError(error_message)
+                        return module.ProcessOutput(
+                            success=False,
+                            check_output={"summary": "Failed to push the changes"},
+                        )
                     message.title = "Pushed the changes"
                     _LOGGER.debug(message)
         else:


### PR DESCRIPTION
## Summary

When `git push` fails in the patch module, the module now returns `ProcessOutput(success=False)` instead of raising `PatchError`. This marks the job as `REPORT_ERROR` (yellow warning) instead of `FAIL` (red danger), distinguishing a push failure from a system error.

## Context

The push failure is an expected operational condition (e.g. branch was updated by another action), not a system error. It should be reported as a module error rather than a job failure.

## Implementation Details

- Replaced `raise PatchError(error_message)` with `return module.ProcessOutput(success=False, check_output={"summary": "Failed to push the changes"})`