### PR TITLE
Internal module: Fix check run creation shadowed by local variable

### DIFF
--- a/github_app_geo_project/module/internal/__init__.py
+++ b/github_app_geo_project/module/internal/__init__.py
@@ -222,7 +222,6 @@ async def process_event(
                 job.module_event_data = module_data
                 context.session.add(job)
                 await context.session.flush()
-                github_project = None
 
                 should_create_checks = action.checks
                 if should_create_checks is None:
@@ -234,12 +233,12 @@ async def process_event(
                         "check_suite",
                         "workflow_run",
                     ]
-                if should_create_checks and github_project is not None:
+                if should_create_checks and context.github_project is not None:
                     await module_utils.create_checks(
                         job,
                         context.session,
                         current_module,
-                        github_project,
+                        context.github_project,
                         context.service_url,
                     )
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
## Summary

Fix the check run creation for the dispatched jobs in the internal module that was broken by a local variable that shadowed the outer scope.

## Context

In `process_event` of the internal module, a local `github_project = None` shadowed the outer scope. Because of that, the `if should_create_checks and github_project is not None:` condition was always `False` and the `create_checks` function was never called for the dispatched child jobs.

## Implementation Details

- Remove the local `github_project = None` shadowing
- Use `context.github_project` in the condition and the `create_checks` call

## Impact/Risks

- The dispatched child jobs now have their check runs correctly created
- No breaking change expected