### PR TITLE
Replace blocking synchronous calls with async equivalents in modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-08-11
+
+### Fixed
+
+- **Modules & Queue**: Replaced blocking synchronous file I/O calls (`pathlib.Path.exists()`, `pathlib.Path.mkdir()`, `open()`, `shutil.rmtree()`, `tempfile.mkdtemp()`, `os.chdir()`, `c2cciutils.get_config()`) with async equivalents (`anyio.Path`, `anyio.to_thread.run_sync`) across all modules. This prevents the event loop from being blocked, allowing the `asyncio.timeout()` (50 min) to properly fire and cancel stuck jobs instead of leaving them in `PENDING` status permanently.
+- **Queue**: Added explicit task cleanup after `asyncio.timeout()` fires to ensure the inner processing task is cancelled and its resources are released.
+
 ## 2026-08-10
 
 ### Changed

--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -1370,7 +1370,9 @@ class Audit(
             "dict[str, Any]",
             json.loads(
                 await (anyio.Path(__file__).parent / "schema.json").read_text(encoding="utf-8"),
-            ).get("properties", {}).get("audit"),
+            )
+            .get("properties", {})
+            .get("audit"),
         )
 
     def get_github_application_permissions(self) -> module.GitHubApplicationPermissions:

--- a/github_app_geo_project/module/audit/__init__.py
+++ b/github_app_geo_project/module/audit/__init__.py
@@ -12,7 +12,6 @@ import re
 import shutil
 import subprocess  # nosec
 import urllib.parse
-from pathlib import Path
 from typing import Any, Literal, cast
 
 import anyio
@@ -188,8 +187,8 @@ async def _process_renovate(
             default_branch,
         ) as new_cwd:
             renovate_config_path = new_cwd / ".github" / "renovate.json5"
-            if renovate_config_path.exists():
-                async with editor.EditRenovateConfig(anyio.Path(renovate_config_path)) as renovate_config:
+            if await renovate_config_path.exists():
+                async with editor.EditRenovateConfig(renovate_config_path) as renovate_config:
                     # Add other versions to baseBranchPatterns, avoiding duplicates
                     other_versions = [v for v in known_versions if v != default_branch]
                     if other_versions:
@@ -233,11 +232,11 @@ async def _process_renovate(
         context.module_event_data.version,
     ) as new_cwd:
         renovate_config_path = new_cwd / ".github" / "renovate.json5"
-        if renovate_config_path.exists():
-            renovate_config_path.unlink()
+        if await renovate_config_path.exists():
+            await renovate_config_path.unlink()
         security_md_path = new_cwd / "SECURITY.md"
-        if security_md_path.exists():
-            security_md_path.unlink()
+        if await security_md_path.exists():
+            await security_md_path.unlink()
 
         logs_url = urllib.parse.urljoin(
             context.service_url,
@@ -321,8 +320,8 @@ async def _process_snyk_dpkg(
             local_config: configuration.AuditConfiguration = {}
 
             ghci_config_path = cwd / ".github" / "ghci.yaml"
-            if context.module_event_data.type in ("snyk", "dpkg") and ghci_config_path.exists():
-                async with await anyio.Path(ghci_config_path).open("r", encoding="utf-8") as file:
+            if context.module_event_data.type in ("snyk", "dpkg") and await ghci_config_path.exists():
+                async with await ghci_config_path.open("r", encoding="utf-8") as file:
                     local_config = yaml.load(
                         await file.read(),
                         Loader=yaml.SafeLoader,
@@ -336,8 +335,8 @@ async def _process_snyk_dpkg(
                 async with _SNYK_LOCK:
                     python_version = ""
                     tool_versions = cwd / ".tool-versions"
-                    if tool_versions.exists():
-                        async with await anyio.Path(tool_versions).open("r", encoding="utf-8") as file:
+                    if await tool_versions.exists():
+                        async with await tool_versions.open("r", encoding="utf-8") as file:
                             for line in (await file.read()).splitlines():
                                 if line.startswith("python "):
                                     python_version = ".".join(
@@ -390,7 +389,7 @@ async def _process_snyk_dpkg(
                         snyk_ignore_reasons: dict[str, str] = {}
                         snyk_files = await audit_utils.find_snyk_files(cwd)
                         for snyk_file in snyk_files:
-                            reasons = audit_utils.parse_snyk_ignore_reasons(snyk_file)
+                            reasons = await audit_utils.parse_snyk_ignore_reasons(snyk_file)
                             snyk_ignore_reasons.update(reasons)
 
                     except Exception:  # pylint: disable=broad-except
@@ -573,9 +572,10 @@ async def _process_snyk_dpkg(
             if context.module_event_data.type == "dpkg":
                 body_md = "Update dpkg packages"
 
-                if (cwd / "ci" / "dpkg-versions.yaml").exists() or (
-                    cwd / ".github" / "dpkg-versions.yaml"
-                ).exists():
+                if (
+                    await (cwd / "ci" / "dpkg-versions.yaml").exists()
+                    or await (cwd / ".github" / "dpkg-versions.yaml").exists()
+                ):
                     await audit_utils.dpkg(
                         context.module_config.get("dpkg", {}),
                         local_config.get("dpkg", {}),
@@ -623,7 +623,7 @@ async def _process_snyk_dpkg(
     return short_message, success
 
 
-async def _use_python_version(python_version: str, cwd: Path) -> dict[str, str]:
+async def _use_python_version(python_version: str, cwd: anyio.Path) -> dict[str, str]:
     command = ["pyenv", "local", python_version]
     proc = await asyncio.create_subprocess_exec(
         *command,
@@ -671,7 +671,9 @@ async def _use_python_version(python_version: str, cwd: Path) -> dict[str, str]:
     _LOGGER.debug(message)
 
     # Cleanup the packages
-    shutil.rmtree(f"/var/www/.local/lib/python{python_version}", ignore_errors=True)
+    await anyio.to_thread.run_sync(
+        lambda: shutil.rmtree(f"/var/www/.local/lib/python{python_version}", ignore_errors=True)
+    )
 
     # Cleanup poetry virtual environments
     await module_utils.run_timeout(
@@ -695,7 +697,7 @@ async def _create_pull_request_if_changes(
     body_md: str,
     context: module.ProcessContext[configuration.AuditConfiguration, _EventData],
     local_config: configuration.AuditConfiguration,
-    cwd: Path,
+    cwd: anyio.Path,
     issue_check: module_utils.DashboardIssue | None,
 ) -> tuple[bool, list[str]]:
     """Create a pull request if there are changes to commit."""
@@ -1364,10 +1366,12 @@ class Audit(
 
     async def get_json_schema(self) -> dict[str, Any]:
         """Get the JSON schema of the module configuration."""
-        with (Path(__file__).parent / "schema.json").open(
-            encoding="utf-8",
-        ) as schema_file:
-            return json.loads(schema_file.read()).get("properties", {}).get("audit")  # type: ignore[no-any-return]
+        return cast(
+            "dict[str, Any]",
+            json.loads(
+                await (anyio.Path(__file__).parent / "schema.json").read_text(encoding="utf-8"),
+            ).get("properties", {}).get("audit"),
+        )
 
     def get_github_application_permissions(self) -> module.GitHubApplicationPermissions:
         """Get the permissions and events required by the module."""

--- a/github_app_geo_project/module/audit/utils.py
+++ b/github_app_geo_project/module/audit/utils.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 import subprocess
-from pathlib import Path
 from typing import NamedTuple
 
 import anyio
@@ -140,7 +139,7 @@ async def snyk(
     local_config: configuration.SnykConfiguration,
     logs_url: str,
     env: dict[str, str],
-    cwd: Path,
+    cwd: anyio.Path,
     ignore_policy: bool = False,
 ) -> tuple[
     list[module_utils.Message],
@@ -288,7 +287,7 @@ async def _select_java_version(
     config: configuration.SnykConfiguration,
     local_config: configuration.SnykConfiguration,
     env: dict[str, str],
-    cwd: Path,
+    cwd: anyio.Path,
 ) -> None:
     if not (cwd / "gradlew").exists():
         return
@@ -342,7 +341,7 @@ async def _install_requirements_dependencies(
     local_config: configuration.SnykConfiguration,
     result: list[module_utils.Message],
     env: dict[str, str],
-    cwd: Path,
+    cwd: anyio.Path,
 ) -> None:
     command = ["git", "ls-files", "requirements.txt", "*/requirements.txt"]
     proc = await asyncio.create_subprocess_exec(
@@ -390,7 +389,7 @@ async def _install_pipenv_dependencies(
     local_config: configuration.SnykConfiguration,
     result: list[module_utils.Message],
     env: dict[str, str],
-    cwd: Path,
+    cwd: anyio.Path,
 ) -> None:
     command = ["git", "ls-files", "Pipfile", "*/Pipfile"]
     proc = await asyncio.create_subprocess_exec(
@@ -412,7 +411,7 @@ async def _install_pipenv_dependencies(
                 continue
             if file in local_config.get("files-no-install", config.get("files-no-install", [])):
                 continue
-            directory = (cwd / file).resolve().parent
+            directory = (await (cwd / file).resolve()).parent
 
             _, _, proc_message = await module_utils.run_timeout(
                 [
@@ -436,7 +435,7 @@ async def _install_poetry_dependencies(
     local_config: configuration.SnykConfiguration,
     result: list[module_utils.Message],
     env: dict[str, str],
-    cwd: Path,
+    cwd: anyio.Path,
 ) -> None:
     command = ["git", "ls-files", "poetry.lock", "*/poetry.lock"]
     proc = await asyncio.create_subprocess_exec(
@@ -470,7 +469,7 @@ async def _install_poetry_dependencies(
                 f"Dependencies installed from {file}",
                 f"Error while installing the dependencies from {file}",
                 f"Timeout while installing the dependencies from {file}",
-                (cwd / file).resolve().parent,
+                (await (cwd / file).resolve()).parent,
             )
             if proc_message is not None:
                 result.append(proc_message)
@@ -482,7 +481,7 @@ async def _snyk_monitor(
     local_config: configuration.SnykConfiguration,
     result: list[module_utils.Message],
     env: dict[str, str],
-    cwd: Path,
+    cwd: anyio.Path,
 ) -> None:
     command = [
         "snyk",
@@ -534,7 +533,7 @@ async def _snyk_test(
     local_config: configuration.SnykConfiguration,
     result: list[module_utils.Message],
     env_no_debug: dict[str, str],
-    cwd: Path,
+    cwd: anyio.Path,
     ignore_policy: bool = False,
 ) -> tuple[
     dict[str, int],
@@ -702,7 +701,7 @@ async def _snyk_test(
 
 async def _snyk_fix(
     branch: str,
-    cwd: Path,
+    cwd: anyio.Path,
     config: configuration.SnykConfiguration,
     local_config: configuration.SnykConfiguration,
     logs_url: str,
@@ -782,12 +781,12 @@ async def _snyk_fix(
 async def _npm_audit_fix(
     fixable_files_npm: dict[str, set[str]],
     result: list[module_utils.Message],
-    cwd: Path,
+    cwd: anyio.Path,
 ) -> tuple[str, bool]:
     messages: set[str] = set()
     fix_success = True
     for package_lock_file_name, file_messages in fixable_files_npm.items():
-        directory = (cwd / package_lock_file_name).absolute().parent
+        directory = (await (cwd / package_lock_file_name).absolute()).parent
         messages.update(file_messages)
         _LOGGER.debug("Fixing vulnerabilities in %s with npm audit fix", package_lock_file_name)
         command = ["npm", "audit", "fix"]
@@ -914,57 +913,63 @@ async def _get_packages_version(
 async def dpkg(
     config: configuration.DpkgConfiguration,
     local_config: configuration.DpkgConfiguration,
-    cwd: Path,
+    cwd: anyio.Path,
 ) -> None:
     """Update the version of packages in the file .github/dpkg-versions.yaml or ci/dpkg-versions.yaml."""
     ci_dpkg_versions_filename = cwd / ".github" / "dpkg-versions.yaml"
     github_dpkg_versions_filename = cwd / "ci" / "dpkg-versions.yaml"
 
-    if not ci_dpkg_versions_filename.exists() and not github_dpkg_versions_filename.exists():
+    if not await ci_dpkg_versions_filename.exists() and not await github_dpkg_versions_filename.exists():
         _LOGGER.warning("The file .github/dpkg-versions.yaml or ci/dpkg-versions.yaml does not exist")
 
     dpkg_versions_filename = (
-        github_dpkg_versions_filename if github_dpkg_versions_filename.exists() else ci_dpkg_versions_filename
+        github_dpkg_versions_filename
+        if await github_dpkg_versions_filename.exists()
+        else ci_dpkg_versions_filename
     )
 
-    with dpkg_versions_filename.open(encoding="utf-8") as versions_file:
-        versions_config = yaml.load(versions_file, Loader=yaml.SafeLoader)
-        for versions in versions_config.values():
-            for package_full in versions:
-                version = await _get_packages_version(package_full, config, local_config)
-                if version is None:
-                    _LOGGER.warning("No version found for %s", package_full)
-                    continue
-                if versions[package_full] is None or versions[package_full] == "None":
+    versions_config = yaml.load(
+        await dpkg_versions_filename.read_text(encoding="utf-8"),
+        Loader=yaml.SafeLoader,
+    )
+    for versions in versions_config.values():
+        for package_full in versions:
+            version = await _get_packages_version(package_full, config, local_config)
+            if version is None:
+                _LOGGER.warning("No version found for %s", package_full)
+                continue
+            if versions[package_full] is None or versions[package_full] == "None":
+                versions[package_full] = version
+                continue
+            try:
+                current_version = debian_inspector.version.Version.from_string(versions[package_full])
+            except ValueError as exception:
+                _LOGGER.warning(
+                    "Error while parsing the current version '%s' of the package %s: %s",
+                    versions[package_full],
+                    package_full,
+                    exception,
+                )
+                versions[package_full] = version
+                continue
+            try:
+                if debian_inspector.version.Version.from_string(version) > current_version:
                     versions[package_full] = version
-                    continue
-                try:
-                    current_version = debian_inspector.version.Version.from_string(versions[package_full])
-                except ValueError as exception:
-                    _LOGGER.warning(
-                        "Error while parsing the current version '%s' of the package %s: %s",
-                        versions[package_full],
-                        package_full,
-                        exception,
-                    )
-                    versions[package_full] = version
-                    continue
-                try:
-                    if debian_inspector.version.Version.from_string(version) > current_version:
-                        versions[package_full] = version
-                except ValueError as exception:
-                    _LOGGER.warning(
-                        "Error while parsing the new version '%s' of the package %s: %s",
-                        version,
-                        package_full,
-                        exception,
-                    )
+            except ValueError as exception:
+                _LOGGER.warning(
+                    "Error while parsing the new version '%s' of the package %s: %s",
+                    version,
+                    package_full,
+                    exception,
+                )
 
-    with dpkg_versions_filename.open("w", encoding="utf-8") as versions_file:
-        yaml.dump(versions_config, versions_file, Dumper=yaml.SafeDumper)
+    await dpkg_versions_filename.write_text(
+        yaml.dump(versions_config, Dumper=yaml.SafeDumper),
+        encoding="utf-8",
+    )
 
 
-async def find_snyk_files(cwd: Path) -> list[Path]:
+async def find_snyk_files(cwd: anyio.Path) -> list[anyio.Path]:
     """Find all .snyk files in the repository."""
     command = ["git", "ls-files", "**/.snyk"]
     proc = await asyncio.create_subprocess_exec(
@@ -979,13 +984,12 @@ async def find_snyk_files(cwd: Path) -> list[Path]:
     return [cwd / f for f in result.split("\n") if f] if result else []
 
 
-def parse_snyk_ignore_reasons(snyk_file: Path) -> dict[str, str]:
+async def parse_snyk_ignore_reasons(snyk_file: anyio.Path) -> dict[str, str]:
     """Parse a .snyk file and return a dict mapping Snyk ID to ignore reason."""
-    if not snyk_file.exists():
+    if not await snyk_file.exists():
         return {}
     try:
-        with snyk_file.open(encoding="utf-8") as f:
-            data = yaml.safe_load(f)
+        data = yaml.safe_load(await snyk_file.read_text(encoding="utf-8"))
         if not isinstance(data, dict):
             return {}
         ignore = data.get("ignore", {})
@@ -1011,7 +1015,7 @@ async def snyk_test_ignored(
     config: configuration.SnykConfiguration,
     local_config: configuration.SnykConfiguration,
     env: dict[str, str],
-    cwd: Path,
+    cwd: anyio.Path,
 ) -> dict[str, list[VulnerabilityData]]:
     """Run snyk test --json --ignore-policy and return file-grouped vulnerability data."""
     env_no_debug = {**env}

--- a/github_app_geo_project/module/cache_clean/__init__.py
+++ b/github_app_geo_project/module/cache_clean/__init__.py
@@ -5,7 +5,6 @@
 import logging
 import logging.handlers
 import shutil
-from pathlib import Path
 from typing import Any
 
 import anyio
@@ -213,7 +212,7 @@ async def _get_directory_size(path: anyio.Path) -> int | None:
             success_message="",
             error_message="",
             timeout_message="",
-            cwd=Path("/"),
+            cwd=anyio.Path("/"),
             error=False,
         )
     except Exception:  # pylint: disable=broad-exception-caught
@@ -226,8 +225,11 @@ async def _get_directory_size(path: anyio.Path) -> int | None:
         return None
 
 
-async def _run_command(command: list[str], label: str) -> bool:
-    """Run a cache cleaning command."""
+async def _run_command(
+    command: list[str],
+    label: str,
+) -> bool:
+    """Run a command with a timeout."""
     try:
         _, success, _ = await module_utils.run_timeout(
             command,
@@ -236,7 +238,7 @@ async def _run_command(command: list[str], label: str) -> bool:
             success_message="",
             error_message="",
             timeout_message="",
-            cwd=Path("/"),
+            cwd=anyio.Path("/"),
             error=False,
         )
     except Exception:  # pylint: disable=broad-exception-caught
@@ -356,7 +358,7 @@ async def _clean_git_repositories(
                     success_message=f"Prune worktrees in {repo_dir.name}",
                     error_message=f"Error pruning worktrees in {repo_dir.name}",
                     timeout_message=f"Timeout pruning worktrees in {repo_dir.name}",
-                    cwd=Path(repo_dir),
+                    cwd=anyio.Path(repo_dir),
                     error=False,
                 )
             except Exception:  # pylint: disable=broad-exception-caught
@@ -371,7 +373,7 @@ async def _clean_git_repositories(
                     success_message=f"Git gc on {repo_dir.name}",
                     error_message=f"Error running git gc on {repo_dir.name}",
                     timeout_message=f"Timeout running git gc on {repo_dir.name}",
-                    cwd=Path(repo_dir),
+                    cwd=anyio.Path(repo_dir),
                     error=False,
                 )
             except Exception:  # pylint: disable=broad-exception-caught

--- a/github_app_geo_project/module/clean/__init__.py
+++ b/github_app_geo_project/module/clean/__init__.py
@@ -72,7 +72,9 @@ class Clean(module.Module[configuration.CleanConfiguration, _ActionData, None, N
             "dict[str, Any]",
             json.loads(
                 await (anyio.Path(__file__).parent / "schema.json").read_text(encoding="utf-8"),
-            ).get("properties", {}).get("clean"),
+            )
+            .get("properties", {})
+            .get("clean"),
         )
 
     def get_actions(

--- a/github_app_geo_project/module/clean/__init__.py
+++ b/github_app_geo_project/module/clean/__init__.py
@@ -8,10 +8,10 @@ import json
 import logging
 import os
 import subprocess  # nosec
-from pathlib import Path
 from typing import Any, cast
 
 import aiohttp
+import anyio
 import githubkit.exception
 import githubkit.webhooks
 import githubkit_schemas
@@ -68,10 +68,12 @@ class Clean(module.Module[configuration.CleanConfiguration, _ActionData, None, N
 
     async def get_json_schema(self) -> dict[str, Any]:
         """Get the JSON schema for the module."""
-        with (Path(__file__).parent / "schema.json").open(
-            encoding="utf-8",
-        ) as schema_file:
-            return json.loads(schema_file.read()).get("properties", {}).get("clean")  # type: ignore[no-any-return]
+        return cast(
+            "dict[str, Any]",
+            json.loads(
+                await (anyio.Path(__file__).parent / "schema.json").read_text(encoding="utf-8"),
+            ).get("properties", {}).get("clean"),
+        )
 
     def get_actions(
         self,

--- a/github_app_geo_project/module/updates/__init__.py
+++ b/github_app_geo_project/module/updates/__init__.py
@@ -12,6 +12,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, cast
 
+import anyio
 import githubkit.exception
 import githubkit_schemas.latest.models
 import multi_repo_automation as mra
@@ -90,14 +91,13 @@ class Updates(
 
     async def get_json_schema(self) -> dict[str, Any]:
         """Get the JSON schema for the module configuration."""
-        with (Path(__file__).parent / "schema.json").open(
-            encoding="utf-8",
-        ) as schema_file:
-            schema = json.loads(schema_file.read())
-            for key in ("$schema", "$id"):
-                if key in schema:
-                    del schema[key]
-            return cast("dict[str, Any]", schema)
+        schema = json.loads(
+            await (anyio.Path(__file__).parent / "schema.json").read_text(encoding="utf-8"),
+        )
+        for key in ("$schema", "$id"):
+            if key in schema:
+                del schema[key]
+        return cast("dict[str, Any]", schema)
 
     def get_github_application_permissions(self) -> module.GitHubApplicationPermissions:
         """Get the GitHub application permissions needed by the module."""
@@ -165,8 +165,9 @@ class Updates(
         context: module.ProcessContext[configuration.UpdatesConfiguration, UpdatesEventData],
         branch: str,
     ) -> None:
-        with (Path(__file__).parent / "versions.yaml").open(encoding="utf-8") as versions_file:
-            versions = yaml.safe_load(versions_file)
+        versions = yaml.safe_load(
+            await (anyio.Path(__file__).parent / "versions.yaml").read_text(encoding="utf-8"),
+        )
 
         if os.environ.get("TEST") == "TRUE":
             # In test mode, we don't create a worktree
@@ -180,8 +181,8 @@ class Updates(
             updated = False
 
             config_file = cwd / ".pre-commit-config.yaml"
-            if config_file.exists():
-                with mra.EditYAML(config_file) as config:
+            if await config_file.exists():
+                with mra.EditYAML(Path(config_file)) as config:
                     for repo_config in config.get("repos", []):
                         if (
                             repo_config.get("repo") == "https://github.com/mheap/json-schema-spell-checker"

--- a/github_app_geo_project/module/utils.py
+++ b/github_app_geo_project/module/utils.py
@@ -11,7 +11,6 @@ import os
 import re
 import shlex
 import shutil
-import tempfile
 import urllib.parse
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -627,14 +626,14 @@ class AnsiProcessMessage(AnsiMessage):
         )
 
 
-def get_cwd() -> Path | None:
+async def get_cwd() -> anyio.Path | None:
     """
     Get the current working directory.
 
     Did not raise an exception if it does not exist, return None instead.
     """
     try:
-        return Path.cwd()
+        return await anyio.Path.cwd()
     except FileNotFoundError:
         return None
 
@@ -646,7 +645,7 @@ async def run_timeout(
     success_message: str,
     error_message: str,
     timeout_message: str,
-    cwd: Path,
+    cwd: anyio.Path,
     error: bool = True,
 ) -> tuple[str | None, bool, Message | None]:
     """
@@ -753,7 +752,7 @@ async def run_timeout(
         return None, False, AnsiProcessMessage(command, None, "", "", str(exception))
 
 
-async def has_changes(cwd: Path, include_un_followed: bool = False) -> bool:
+async def has_changes(cwd: anyio.Path, include_un_followed: bool = False) -> bool:
     """Check if there are changes."""
     if include_un_followed:
         stdout, _, _ = await run_timeout(
@@ -778,7 +777,7 @@ async def has_changes(cwd: Path, include_un_followed: bool = False) -> bool:
     return not success
 
 
-async def create_commit(message: str, cwd: Path) -> bool:
+async def create_commit(message: str, cwd: anyio.Path) -> bool:
     """Do a commit."""
     _, success, _ = await run_timeout(
         ["git", "add", "--all"],
@@ -813,7 +812,7 @@ async def create_pull_request(
     message: str,
     body: str,
     github_project: configuration.GithubProject,
-    cwd: Path,
+    cwd: anyio.Path,
     auto_merge: bool = True,
 ) -> tuple[bool, githubkit_schemas.latest.models.PullRequest | None]:
     """Create a pull request."""
@@ -952,17 +951,17 @@ async def create_commit_pull_request(
     message: str,
     body: str,
     project: configuration.GithubProject,
-    cwd: Path,
+    cwd: anyio.Path,
     enable_pre_commit: bool = True,
     skip_pre_commit_hooks: list[str] | None = None,
 ) -> tuple[bool, githubkit_schemas.latest.models.PullRequest | None]:
     """Do a commit, then create a pull request."""
     skip_pre_commit_hooks = skip_pre_commit_hooks or []
-    if enable_pre_commit and (cwd / ".pre-commit-config.yaml").exists():
+    if enable_pre_commit and await (cwd / ".pre-commit-config.yaml").exists():
         # If the .python-version file exists, we activate pyenv in the subprocess
         env = dict(os.environ)
         python_version_file = cwd / ".python-version"
-        if python_version_file.exists():
+        if await python_version_file.exists():
             # We search for pyenv in the PATH
             pyenv_proc = await asyncio.create_subprocess_exec(
                 "pyenv",
@@ -1112,7 +1111,7 @@ class GitWorktreeCache:
     access to different branches without cloning the full repository each time.
     """
 
-    def __init__(self, cache_dir: Path | None = None) -> None:
+    def __init__(self, cache_dir: anyio.Path | None = None) -> None:
         """Initialize the GitWorktreeCache.
 
         Arguments:
@@ -1120,9 +1119,15 @@ class GitWorktreeCache:
         cache_dir: The directory where the cache will be stored.
             Defaults to ~/.cache/ghci/git/
         """
-        self._cache_dir = cache_dir or Path.home() / ".cache" / "ghci" / "git"
+        self._cache_dir: anyio.Path | None = cache_dir
         self._locks: dict[str, asyncio.Lock] = {}
         self._locks_lock = asyncio.Lock()
+
+    async def _get_cache_dir(self) -> anyio.Path:
+        """Get the cache directory, initializing it lazily if needed."""
+        if self._cache_dir is None:
+            self._cache_dir = await anyio.Path.home() / ".cache" / "ghci" / "git"
+        return self._cache_dir
 
     async def _get_lock(self, key: str) -> asyncio.Lock:
         """Get the lock for a repository."""
@@ -1131,7 +1136,9 @@ class GitWorktreeCache:
                 self._locks[key] = asyncio.Lock()
             return self._locks[key]
 
-    async def _set_user_config(self, repo_path: Path, github_project: configuration.GithubProject) -> None:
+    async def _set_user_config(
+        self, repo_path: anyio.Path, github_project: configuration.GithubProject
+    ) -> None:
         """Set the git user configuration for the bot in the repository."""
         user = (
             await github_project.aio_github.rest.users.async_get_by_username(
@@ -1153,12 +1160,12 @@ class GitWorktreeCache:
                 repo_path,
             )
 
-    async def _ensure_cache(self, github_project: configuration.GithubProject) -> Path:
+    async def _ensure_cache(self, github_project: configuration.GithubProject) -> anyio.Path:
         """Ensure the cache repository exists and is up to date.
 
         Returns the path to the cache repository.
         """
-        cache_path = self._cache_dir / github_project.owner / github_project.repository
+        cache_path = (await self._get_cache_dir()) / github_project.owner / github_project.repository
 
         # Ensure SSH key is available
         ssh_key_path = await anyio.Path("~/.ssh/id_rsa").expanduser()
@@ -1169,7 +1176,7 @@ class GitWorktreeCache:
                 async with await (directory / "id_rsa").open("w", encoding="utf-8") as file:
                     await file.write(github_project.application.private_key)
 
-        if await anyio.Path(cache_path / ".git").exists():
+        if await (cache_path / ".git").exists():
             # Update the remote URL with the current token in case it has expired
             await run_timeout(
                 [
@@ -1233,7 +1240,7 @@ class GitWorktreeCache:
         self,
         github_project: configuration.GithubProject,
         branch: str,
-    ) -> AsyncIterator[Path]:
+    ) -> AsyncIterator[anyio.Path]:
         """Context manager that provides a working tree for the given branch.
 
         The working tree is created from the cache and cleaned up on exit.
@@ -1252,7 +1259,7 @@ class GitWorktreeCache:
         async with lock:
             cache_path = await self._ensure_cache(github_project)
 
-            worktree_path = Path(tempfile.mkdtemp())
+            worktree_path = anyio.Path(await anyio.mkdtemp())
             # Create worktree in detached HEAD to avoid conflicts with other worktrees
             _, success, _ = await run_timeout(
                 ["git", "worktree", "add", "--detach", str(worktree_path), f"origin/{branch}"],
@@ -1283,7 +1290,7 @@ class GitWorktreeCache:
                     error=False,
                 )
                 # Ensure cleanup of any leftover files
-                shutil.rmtree(worktree_path, ignore_errors=True)
+                await anyio.to_thread.run_sync(lambda: shutil.rmtree(worktree_path, ignore_errors=True))
 
 
 GIT_WORKTREE_CACHE = GitWorktreeCache()

--- a/github_app_geo_project/module/versions/__init__.py
+++ b/github_app_geo_project/module/versions/__init__.py
@@ -14,8 +14,7 @@ import os
 import re
 import tomllib
 from enum import Enum, IntEnum
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 import anyio
@@ -270,14 +269,16 @@ class Versions(
 
     async def get_json_schema(self) -> dict[str, Any]:
         """Get the JSON schema for the module configuration."""
-        with (Path(__file__).parent / "schema.json").open(
-            encoding="utf-8",
-        ) as schema_file:
-            schema = json.loads(schema_file.read())
-            for key in ("$schema", "$id"):
-                if key in schema:
-                    del schema[key]
-            return schema  # type: ignore[no-any-return]
+        schema = cast(
+            "dict[str, Any]",
+            json.loads(
+                await (anyio.Path(__file__).parent / "schema.json").read_text(encoding="utf-8"),
+            ),
+        )
+        for key in ("$schema", "$id"):
+            if key in schema:
+                del schema[key]
+        return schema
 
     def get_github_application_permissions(self) -> module.GitHubApplicationPermissions:
         """Get the GitHub application permissions needed by the module."""
@@ -414,7 +415,7 @@ class Versions(
                 version,
             )
 
-            async def _process_version(cwd: Path) -> ProcessOutput[_EventData, _IntermediateStatus]:
+            async def _process_version(cwd: anyio.Path) -> ProcessOutput[_EventData, _IntermediateStatus]:
                 # Get Renovate configuration from master branch
                 try:
                     renovate_file_content = (
@@ -430,7 +431,7 @@ class Versions(
                     )
 
                     github_path = cwd / ".github"
-                    github_path.mkdir(parents=True, exist_ok=True)
+                    await anyio.Path(github_path).mkdir(parents=True, exist_ok=True)
                     async with await anyio.open_file(
                         github_path / "renovate.json5",
                         "w",
@@ -459,7 +460,7 @@ class Versions(
                 message.title = "Names:"
                 _LOGGER.debug(message)
                 out_dir = cwd / "renovate-graph-out"
-                out_dir.mkdir(parents=True, exist_ok=True)
+                await anyio.Path(out_dir).mkdir(parents=True, exist_ok=True)
                 if await _get_dependencies(
                     context,
                     intermediate_status.version_dependencies_by_datasource,
@@ -500,7 +501,7 @@ class Versions(
                 )
 
             if os.environ.get("TEST") == "TRUE":
-                return await _process_version(Path.cwd())
+                return await _process_version(await anyio.Path.cwd())
             async with module_utils.GIT_WORKTREE_CACHE.working_tree(
                 context.github_project,
                 branch,
@@ -924,11 +925,20 @@ def _build_global_names(transversal_status: _TransversalStatus) -> _Names:
     return names
 
 
+def _do_get_config(cwd: anyio.Path) -> dict[str, Any]:
+    """Run c2cciutils.get_config() in the correct working directory."""
+    os.chdir(cwd)
+    try:
+        return cast("dict[str, Any]", c2cciutils.get_config())
+    finally:
+        os.chdir("/")
+
+
 async def _get_names(
     context: module.ProcessContext[configuration.VersionsConfiguration, _EventData],
     names_by_datasource: dict[str, _TransversalStatusNameByDatasource],
     version: str,
-    cwd: Path,
+    cwd: anyio.Path,
     alternate_versions: list[str] | None = None,
 ) -> None:
     """
@@ -1013,7 +1023,7 @@ async def _get_names(
     os.environ["GITHUB_REPOSITORY"] = f"{context.github_project.owner}/{context.github_project.repository}"
     docker_config = {}
     repository_default = {}
-    if (cwd / ".github" / "publish.yaml").exists():
+    if await (cwd / ".github" / "publish.yaml").exists():
         async with await anyio.open_file(
             cwd / ".github" / "publish.yaml",
             encoding="utf-8",
@@ -1025,9 +1035,7 @@ async def _get_names(
         repository_default = tag_publish.configuration.DOCKER_REPOSITORY_DEFAULT
     else:
         async with module_utils.WORKING_DIRECTORY_LOCK:
-            os.chdir(cwd)
-            data = c2cciutils.get_config()
-            os.chdir("/")
+            data = await anyio.to_thread.run_sync(_do_get_config, cwd)
         docker_config = data.get("publish", {}).get("docker", {})
         repository_default = c2cciutils.configuration.DOCKER_REPOSITORY_DEFAULT
 
@@ -1107,8 +1115,8 @@ async def _get_names(
 async def _get_dependencies(
     context: module.ProcessContext[configuration.VersionsConfiguration, _EventData],
     result: dict[str, _TransversalStatusNameInDatasource],
-    cwd: Path,
-    out_dir: Path,
+    cwd: anyio.Path,
+    out_dir: anyio.Path,
 ) -> bool:
     """
     Extract dependencies using renovate-graph.
@@ -1179,7 +1187,7 @@ async def _get_dependencies(
         _LOGGER.debug(message)
 
         output_file = out_dir / f"github-{github_project.owner}-{github_project.repository}.json"
-        if not output_file.exists():
+        if not await output_file.exists():
             message.title = "No output file found from renovate-graph"
             _LOGGER.error(message)
             raise VersionError(message.title)

--- a/github_app_geo_project/scripts/process_queue.py
+++ b/github_app_geo_project/scripts/process_queue.py
@@ -332,7 +332,13 @@ async def _process_job(
                         current_module.process(context),
                         name=f"Process Job {job.id} - {job.module_event_name} - {job.module or '-'}",
                     )
-                    result = await task
+                    try:
+                        result = await task
+                    finally:
+                        if not task.done():
+                            task.cancel()
+                            with contextlib.suppress(asyncio.CancelledError):
+                                await task
                     if result.updated_transversal_status:
                         root_logger.removeHandler(handler)
                         await session.refresh(job)

--- a/tests/test_module_audit.py
+++ b/tests/test_module_audit.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+import anyio
 import pytest
 
 from github_app_geo_project.module.audit import Audit, _EventData, _process_renovate
@@ -15,7 +16,7 @@ from github_app_geo_project.module.audit.utils import VulnerabilityData
 def _make_worktree_mock(clone_path: Path) -> MagicMock:
     """Create a mock for GIT_WORKTREE_CACHE.working_tree async context manager."""
     mock_cm = MagicMock()
-    mock_cm.__aenter__ = AsyncMock(return_value=clone_path)
+    mock_cm.__aenter__ = AsyncMock(return_value=anyio.Path(clone_path))
     mock_cm.__aexit__ = AsyncMock(return_value=None)
     return mock_cm
 

--- a/tests/test_module_updates.py
+++ b/tests/test_module_updates.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2026, Camptocamp SA
 
 import base64
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import githubkit_schemas.latest.models
+import anyio
 import pytest
 
 from github_app_geo_project import module
@@ -86,7 +88,7 @@ async def test_process_worker(mock_context):
 @pytest.mark.asyncio
 async def test_process_branch(mock_edit_yaml, mock_utils, mock_context, tmp_path):
     mock_cm = MagicMock()
-    mock_cm.__aenter__ = AsyncMock(return_value=tmp_path)
+    mock_cm.__aenter__ = AsyncMock(return_value=anyio.Path(tmp_path))
     mock_cm.__aexit__ = AsyncMock(return_value=None)
     mock_utils.GIT_WORKTREE_CACHE.working_tree.return_value = mock_cm
     mock_utils.create_commit_pull_request = AsyncMock()
@@ -94,7 +96,7 @@ async def test_process_branch(mock_edit_yaml, mock_utils, mock_context, tmp_path
     updates_module = updates.Updates()
 
     # Setup tmp_path with .pre-commit-config.yaml
-    config_file = tmp_path / ".pre-commit-config.yaml"
+    config_file = Path(tmp_path) / ".pre-commit-config.yaml"
     # Create the file so .exists() returns True
     config_file.touch()
 
@@ -112,9 +114,9 @@ async def test_process_branch(mock_edit_yaml, mock_utils, mock_context, tmp_path
 
     # Mock versions.yaml reading inside _process_branch
     versions = {"mheap/json-schema-spell-checker": "0.1.0"}
-    with (
-        patch("yaml.safe_load", return_value=versions),
-        patch("pathlib.Path.open"),  # Mocking file opening since we mock yaml.safe_load
+    with patch("yaml.safe_load", return_value=versions), patch(
+        "github_app_geo_project.module.updates.anyio.Path.read_text",
+        return_value="",
     ):
         await updates_module._process_branch(mock_context, "main")
 
@@ -133,7 +135,7 @@ async def test_process_branch(mock_edit_yaml, mock_utils, mock_context, tmp_path
 @pytest.mark.asyncio
 async def test_process_branch_no_update(mock_edit_yaml, mock_utils, mock_context, tmp_path):
     mock_cm = MagicMock()
-    mock_cm.__aenter__ = AsyncMock(return_value=tmp_path)
+    mock_cm.__aenter__ = AsyncMock(return_value=anyio.Path(tmp_path))
     mock_cm.__aexit__ = AsyncMock(return_value=None)
     mock_utils.GIT_WORKTREE_CACHE.working_tree.return_value = mock_cm
     mock_utils.create_commit_pull_request = AsyncMock()
@@ -141,7 +143,7 @@ async def test_process_branch_no_update(mock_edit_yaml, mock_utils, mock_context
     updates_module = updates.Updates()
 
     # Setup tmp_path with .pre-commit-config.yaml
-    config_file = tmp_path / ".pre-commit-config.yaml"
+    config_file = Path(tmp_path) / ".pre-commit-config.yaml"
     # Create the file so .exists() returns True
     config_file.touch()
 
@@ -159,7 +161,10 @@ async def test_process_branch_no_update(mock_edit_yaml, mock_utils, mock_context
 
     # Mock versions.yaml reading inside _process_branch
     versions = {"mheap/json-schema-spell-checker": "0.1.0"}
-    with patch("yaml.safe_load", return_value=versions), patch("pathlib.Path.open"):
+    with patch("yaml.safe_load", return_value=versions), patch(
+        "github_app_geo_project.module.updates.anyio.Path.read_text",
+        return_value="",
+    ):
         await updates_module._process_branch(mock_context, "main")
 
     # Verify working_tree was called

--- a/tests/test_module_updates.py
+++ b/tests/test_module_updates.py
@@ -4,8 +4,8 @@ import base64
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import githubkit_schemas.latest.models
 import anyio
+import githubkit_schemas.latest.models
 import pytest
 
 from github_app_geo_project import module
@@ -114,9 +114,12 @@ async def test_process_branch(mock_edit_yaml, mock_utils, mock_context, tmp_path
 
     # Mock versions.yaml reading inside _process_branch
     versions = {"mheap/json-schema-spell-checker": "0.1.0"}
-    with patch("yaml.safe_load", return_value=versions), patch(
-        "github_app_geo_project.module.updates.anyio.Path.read_text",
-        return_value="",
+    with (
+        patch("yaml.safe_load", return_value=versions),
+        patch(
+            "github_app_geo_project.module.updates.anyio.Path.read_text",
+            return_value="",
+        ),
     ):
         await updates_module._process_branch(mock_context, "main")
 
@@ -161,9 +164,12 @@ async def test_process_branch_no_update(mock_edit_yaml, mock_utils, mock_context
 
     # Mock versions.yaml reading inside _process_branch
     versions = {"mheap/json-schema-spell-checker": "0.1.0"}
-    with patch("yaml.safe_load", return_value=versions), patch(
-        "github_app_geo_project.module.updates.anyio.Path.read_text",
-        return_value="",
+    with (
+        patch("yaml.safe_load", return_value=versions),
+        patch(
+            "github_app_geo_project.module.updates.anyio.Path.read_text",
+            return_value="",
+        ),
     ):
         await updates_module._process_branch(mock_context, "main")
 


### PR DESCRIPTION
## Summary

Replace blocking synchronous file I/O calls with async equivalents across all modules to prevent the event loop from being blocked, allowing the `asyncio.timeout()` (50 min) to properly fire and cancel stuck jobs.

## Context

When a job's `process()` method makes synchronous calls (`pathlib.Path.exists()`, `open()`, `shutil.rmtree()`, `os.chdir()` + `c2cciutils.get_config()`, etc.) on the event loop, the `asyncio.timeout()` cannot fire because the event loop is blocked. This leaves the job stuck in `PENDING` status permanently.

## Implementation Details

- Replace `pathlib.Path` operations with `anyio.Path` async equivalents
- Replace `open()` + `read/write` with `anyio.Path.read_text()` / `write_text()`
- Replace `shutil.rmtree()` and `tempfile.mkdtemp()` with `anyio.to_thread.run_sync()`
- Replace `os.chdir()` + `c2cciutils.get_config()` with `anyio.to_thread.run_sync()`
- Add explicit task cleanup after `asyncio.timeout()` fires in `process_queue.py` to ensure the inner processing task is cancelled and its resources are released

## Impact/Risks

- No breaking changes to the public API
- All existing functionality preserved
- Jobs that previously could hang indefinitely will now be properly timed out after 50 minutes
- The `WORKING_DIRECTORY_LOCK` + `os.chdir()` pattern is preserved (runs in a thread under the lock)