### PR TITLE
Pin ruff and pylint in the project

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6459,4 +6459,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "a760895b44035f3ad6dd739ebb6645508ddd8d770d595b53c70d5f9575df3b05"
+content-hash = "7492d20a79aa87101cde64c7022e3729835f0f522a714dee66d06acd33472862"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,8 @@ mypy = "2.3.0"
 requests = "2.34.2"
 types-pyyaml = "6.0.12.20260724"
 types-markdown = "3.10.2.20260712"
+ruff = "0.16.1"
+pylint = "4.0.6"
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
Prospector uses ruff and pylint, they should be pinned alongside prospector.