### PR TITLE
Pin ruff and pylint in the project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,6 +118,7 @@ repos:
         additional_dependencies:
           - prospector-profile-utils==1.27.0 # pypi
           - ruff==0.16.1 # pypi
+          - pylint[spelling]==4.0.6 # pypi
   - repo: https://github.com/camptocamp/jsonschema-gentypes
     rev: 2.13.0
     hooks:


### PR DESCRIPTION
Prospector uses ruff and pylint, they should be pinned alongside prospector.