### PR TITLE
Add missing await on anyio.Path.exists() calls

### DIFF
--- a/github_app_geo_project/module/audit/utils.py
+++ b/github_app_geo_project/module/audit/utils.py
@@ -229,7 +229,7 @@ async def snyk(
     fix_success = True
 
     pre_commit_config = get_pre_commit_config(audit_config, audit_local_config)
-    if pre_commit_config.get("enabled", True) and (cwd / ".pre-commit-config.yaml").exists():
+    if pre_commit_config.get("enabled", True) and await (cwd / ".pre-commit-config.yaml").exists():
         command = [
             "pre-commit",
             "run",
@@ -289,7 +289,7 @@ async def _select_java_version(
     env: dict[str, str],
     cwd: anyio.Path,
 ) -> None:
-    if not (cwd / "gradlew").exists():
+    if not await (cwd / "gradlew").exists():
         return
 
     command = ["./gradlew", "--version"]

--- a/github_app_geo_project/module/clean/__init__.py
+++ b/github_app_geo_project/module/clean/__init__.py
@@ -423,7 +423,7 @@ class Clean(module.Module[configuration.CleanConfiguration, _ActionData, None, N
                 except Exception:  # pylint: disable=broad-exception-caught
                     _LOGGER.exception("Error while running 'tree' command")
 
-                if not (cwd / folder).exists():
+                if not await (cwd / folder).exists():
                     _LOGGER.info(
                         "The folder '%s' does not exist in the branch '%s', nothing to do",
                         folder,


### PR DESCRIPTION
## Summary
Add missing `await` on three `anyio.Path.exists()` calls that were silently bypassed because `exists()` is async and returns a truthy coroutine object without `await`.

## Context
The audit module was invoking Java (`./gradlew --version`) for Python projects that don't have a `gradlew` file. The root cause was that `(cwd / "gradlew").exists()` returned a coroutine (always truthy) instead of the actual boolean, so the early-return guard never triggered.

## Implementation Details
- `audit/utils.py:292` — `(cwd / "gradlew").exists()` → `await (cwd / "gradlew").exists()`
- `audit/utils.py:232` — `(cwd / ".pre-commit-config.yaml").exists()` → `await (cwd / ".pre-commit-config.yaml").exists()`
- `clean/__init__.py:426` — `(cwd / folder).exists()` → `await (cwd / folder).exists()`

## Impact/Risks
No breaking change. Fixes false-positive Java invocations and unnecessary pre-commit runs.