### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/failed.yaml
+++ b/.github/workflows/failed.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   main1:
     name: Main 1


### PR DESCRIPTION
## Summary
Add explicit workflow permissions to the failed workflow to follow the principle of least privilege.

## Context
GitHub Actions workflows should declare explicit permissions rather than relying on the default broad permissions. This is a security best practice recommended by GitHub.

## Implementation Details
- `.github/workflows/failed.yaml`: Added top-level `permissions: contents: read`